### PR TITLE
Fix typo in how to setup for README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,7 +36,7 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
 このリポジトリをクローンします:
 
 ```
-git clone git@github.com/line/line-bot-mcp-server.git
+git clone git@github.com:line/line-bot-mcp-server.git
 ```
 
 Node.jsを利用する場合は、必要な依存関係をインストールし、line-bot-mcp-serverをビルドします。Dockerを利用する場合は不要です。:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ requirements:
 Clone this repository:
 
 ```
-git clone git@github.com/line/line-bot-mcp-server.git
+git clone git@github.com:line/line-bot-mcp-server.git
 ```
 
 Install the necessary dependencies and build line-bot-mcp-server when using Node.js. This step is not required when using Docker:


### PR DESCRIPTION
**Detail**

This pull request corrects a typo in the README section on installation instructions.
See https://github.com/line/line-bot-mcp-server/blob/6f15451e17a7cb15e21270419be984902673cad2/README.md#installation