### PR TITLE
add zod package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@line/bot-sdk": "^9.8.0",
-        "@modelcontextprotocol/sdk": "^1.8.0"
+        "@modelcontextprotocol/sdk": "^1.8.0",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@types/node": "^22",

--- a/package.json
+++ b/package.json
@@ -32,14 +32,16 @@
   "bugs": "https://github.com/line/line-bot-mcp-server/issues",
   "dependencies": {
     "@line/bot-sdk": "^9.8.0",
-    "@modelcontextprotocol/sdk": "^1.8.0"
+    "@modelcontextprotocol/sdk": "^1.8.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/node": "^22",
+    "prettier": "3.5.3",
     "shx": "^0.4.0",
     "tsx": "^4.19.3",
-    "typescript": "^5.6.2",
-    "prettier": "3.5.3"
+    "typescript": "^5.6.2"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "packageManager": "pnpm@10.7.1+sha512.2d92c86b7928dc8284f53494fb4201f983da65f0fb4f0d40baafa5cf628fa31dae3e5968f12466f17df7e97310e30f343a648baea1b9b350685dafafffdf5808"
 }


### PR DESCRIPTION
# Background
Hi! My name is 4geru. I'm a member of LINE API Expert.
I set up the local environment. However, I got an error that did not find the zod package and some syntaxes.

<details>

<summary>log</summary>

```typescript
 → pnpm run build
! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing pnpm@10.7.1+sha512.2d92c86b7928dc8284f53494fb4201f983da65f0fb4f0d40baafa5cf628fa31dae3e5968f12466f17df7e97310e30f343a648baea1b9b350685dafafffdf5808.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager


> @line/line-bot-mcp-server@0.0.1 prebuild /Users/uchinishi.koichi/train/line-bot-mcp-server
> npm run format:check && npm run clean


> @line/line-bot-mcp-server@0.0.1 format:check
> npm run prettier -- -l


> @line/line-bot-mcp-server@0.0.1 prettier
> prettier "src/**/*.ts" -l


> @line/line-bot-mcp-server@0.0.1 clean
> rm -rf dist/*


> @line/line-bot-mcp-server@0.0.1 build /Users/uchinishi.koichi/train/line-bot-mcp-server
> tsc && shx chmod +x dist/*.js

src/index.ts:20:19 - error TS2307: Cannot find module 'zod' or its corresponding type declarations.

20 import { z } from "zod";
                     ~~~~~

src/index.ts:58:7 - error TS2322: Type 'unknown' is not assignable to type 'string'.

58       to: userId ?? destinationId,
         ~~

  node_modules/.pnpm/@line+bot-sdk@9.8.0/node_modules/@line/bot-sdk/dist/messaging-api/model/pushMessageRequest.d.ts:19:5
    19     to: string;
           ~~
    The expected type comes from property 'to' which is declared here on type 'PushMessageRequest'

src/index.ts:108:7 - error TS2322: Type 'unknown' is not assignable to type 'string'.

108       to: userId ?? destinationId,
          ~~

  node_modules/.pnpm/@line+bot-sdk@9.8.0/node_modules/@line/bot-sdk/dist/messaging-api/model/pushMessageRequest.d.ts:19:5
    19     to: string;
           ~~
    The expected type comes from property 'to' which is declared here on type 'PushMessageRequest'

src/index.ts:135:7 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.

135       userId ?? destinationId,
          ~~~~~~~~~~~~~~~~~~~~~~~


Found 4 errors in the same file, starting at: src/index.ts:20

 ELIFECYCLE  Command failed with exit code 2.
```

</details>

After installing zod package. The build was a success. 🎉 