### PR TITLE
Add broadcast Tools

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -66,7 +66,7 @@ Claude DesktopやClaudeなどのAI Agentに次の設定を追加してくださ�
 環境変数や引数は次のように設定してください:
 
 - `mcpServers.args`: (必須) `line-bot-mcp-server`へのパス。
-- `CHANNEL_ACCESS_TOKEN`: (必須) チャンネルアクセストークン。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/basics/channel-access-token/#long-lived-channel-access-token)に従ってください。
+- `CHANNEL_ACCESS_TOKEN`: (必須) チャネルアクセストークン。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/basics/channel-access-token/#long-lived-channel-access-token)に従ってください。
 - `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
 
 #### Option 1: Node.jsを利用する場合

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,21 +10,31 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
 ## Tools
 
 1. **push_text_message**
-   - LINEでユーザーにシンプルなテキストメッセージを送信する
+   - LINEでユーザーにシンプルなテキストメッセージを送信する。
    - **入力:**
-     - `user_id` (string): メッセージ受信者のユーザーID。デフォルトはDESTINATION_USER_ID。
+     - `user_id` (string?): メッセージ受信者のユーザーID。デフォルトはDESTINATION_USER_ID。
      - `message.text` (string): ユーザーに送信するテキスト。
 2. **push_flex_message**
-   - LINEでユーザーに高度にカスタマイズ可能なフレックスメッセージを送信する。バブル（単一コンテナ）とカルーセル（スワイプ可能な複数のバブル）レイアウトの両方をサポート。
+   - LINEでユーザーに高度にカスタマイズ可能なフレックスメッセージを送信する。
    - **入力:**
-     - `user_id` (string): メッセージ受信者のユーザーID。デフォルトはDESTINATION_USER_ID。
+     - `user_id` (string?): メッセージ受信者のユーザーID。デフォルトはDESTINATION_USER_ID。
      - `message.altText` (string): フレックスメッセージが表示できない場合に表示される代替テキスト。
      - `message.content` (any): フレックスメッセージの内容。メッセージのレイアウトとコンポーネントを定義するJSONオブジェクト。
      - `message.contents.type` (enum): コンテナのタイプ。'bubble'は単一コンテナ、'carousel'は複数のスワイプ可能なバブルを示す。
-3. **get_profile**
+3. **broadcast_text_message**
+   - LINE公式アカウントと友だちになっているすべてのユーザーに、LINEでシンプルなテキストメッセージを送信する。
+   - **入力:**
+     - `message.text` (string): ユーザーに送信するテキスト。
+4. **broadcast_flex_message**
+   - LINE公式アカウントと友だちになっているすべてのユーザーに、LINEで高度にカスタマイズ可能なフレックスメッセージを送信する。
+   - **入力:**
+     - `message.altText` (string): フレックスメッセージが表示できない場合に表示される代替テキスト。
+     - `message.content` (any): フレックスメッセージの内容。メッセージのレイアウトとコンポーネントを定義するJSONオブジェクト。
+     - `message.contents.type` (enum): コンテナのタイプ。'bubble'は単一コンテナ、'carousel'は複数のスワイプ可能なバブルを示す。
+5. **get_profile**
    - LINEユーザーの詳細なプロフィール情報を取得する。表示名、プロフィール画像URL、ステータスメッセージ、言語を取得できる。
    - **Inputs:**
-      - `user_id` (string): プロフィールを取得したいユーザーのユーザーID。デフォルトはDESTINATION_USER_ID。
+      - `user_id` (string?): プロフィールを取得したいユーザーのユーザーID。デフォルトはDESTINATION_USER_ID。
 
 ## インストール
 
@@ -45,20 +55,19 @@ Node.jsを利用する場合は、必要な依存関係をインストールし�
 cd line-bot-mcp-server && npm install && npm run build
 ```
 
-### Step 2: チャンネルアクセストークンを取得
+### Step 2: LINE公式アカウントを作成
 
-このMCP ServerはLINE公式アカウントを利用しています。公式アカウントをお持ちでない場合は、[こちらの手順](https://www.linebiz.com/jp-en/manual/OfficialAccountManager/new_account/)に従って作成してください。
-
-Messaging APIに接続するには、チャンネルアクセストークンが必要です。これを確認するには、[こちらの手順](https://developers.line.biz/en/docs/basics/channel-access-token/#long-lived-channel-access-token)に従ってください。
-
-加えて、メッセージの受信者のユーザーIDも必要です。これを確認するには、[こちらの手順](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
-
+このMCP ServerはLINE公式アカウントを利用しています。公式アカウントをお持ちでない場合は、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-started)に従って作成してください。
 
 ### Step 3: AI Agentを設定
 
 Claude DesktopやClaudeなどのAI Agentに次の設定を追加してください。
-`CHANNEL_ACCESS_TOKEN`と`DESTINATION_USER_ID`には、先ほど取得したチャンネルアクセストークンとユーザーIDをそれぞれ挿入してください。
-加えて、`mcpServers.args`にある`line-bot-mcp-server`へのパスを更新してください。
+
+環境変数や引数は次のように設定してください:
+
+- `mcpServers.args`: (必須) `line-bot-mcp-server`へのパス。
+- `CHANNEL_ACCESS_TOKEN`: (必須) チャンネルアクセストークン。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/basics/channel-access-token/#long-lived-channel-access-token)に従ってください。
+- `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
 
 #### Option 1: Node.jsを利用する場合
 

--- a/README.md
+++ b/README.md
@@ -12,21 +12,31 @@
 ## Tools
 
 1. **push_text_message**
-   - Push a simple text message to user via LINE.
+   - Push a simple text message to a user via LINE.
    - **Inputs:**
-     - `user_id` (string): The user ID to receive a message. Defaults to DESTINATION_USER_ID.
+     - `user_id` (string?): The user ID to receive a message. Defaults to DESTINATION_USER_ID.
      - `message.text` (string): The plain text content to send to the user.
 2. **push_flex_message**
-   - Push a highly customizable flex message to user via LINE. Supports both bubble (single container) and carousel (multiple swipeable bubbles) layouts.
+   - Push a highly customizable flex message to a user via LINE.
    - **Inputs:**
-     - `user_id` (string): The user ID to receive a message. Defaults to DESTINATION_USER_ID.
+     - `user_id` (string?): The user ID to receive a message. Defaults to DESTINATION_USER_ID.
      - `message.altText` (string): Alternative text shown when flex message cannot be displayed.
      - `message.content` (any): The content of the flex message. This is a JSON object that defines the layout and components of the message.
      - `message.contents.type` (enum): Type of the container. 'bubble' for single container, 'carousel' for multiple swipeable bubbles.
-3. **get_profile**
+3. **broadcast_text_message**
+   - Broadcast a simple text message via LINE to all users who have followed your LINE Official Account.
+   - **Inputs:**
+     - `message.text` (string): The plain text content to send to the users.
+4. **broadcast_flex_message**
+   - Broadcast a highly customizable flex message via LINE to all users who have added your LINE Official Account.
+   - **Inputs:**
+     - `message.altText` (string): Alternative text shown when flex message cannot be displayed.
+     - `message.content` (any): The content of the flex message. This is a JSON object that defines the layout and components of the message.
+     - `message.contents.type` (enum): Type of the container. 'bubble' for single container, 'carousel' for multiple swipeable bubbles.
+5. **get_profile**
    - Get detailed profile information of a LINE user including display name, profile picture URL, status message and language.
    - **Inputs:**
-     - `user_id` (string): The ID of the user whose profile you want to retrieve. Defaults to DESTINATION_USER_ID.
+     - `user_id` (string?): The ID of the user whose profile you want to retrieve. Defaults to DESTINATION_USER_ID.
 
 
 ## Installation
@@ -48,19 +58,18 @@ Install the necessary dependencies and build line-bot-mcp-server when using Node
 cd line-bot-mcp-server && npm install && npm run build
 ```
 
-### Step 2: Get a channel access token
+### Step 2: Create LINE Official Account
 
-This MCP server utilizes a LINE Official Account. If you do not have one, please create it by following [this instructions](https://www.linebiz.com/jp-en/manual/OfficialAccountManager/new_account/). 
-
-To connect to the Messaging API, you need to have a channel access token. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/basics/channel-access-token/#long-lived-channel-access-token).
-
-Additionally, you will need the user ID of the recipient user for messages. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
+This MCP server utilizes a LINE Official Account. If you do not have one, please create it by following [this instructions](https://www.linebiz.com/jp-en/manual/OfficialAccountManager/new_account/).
 
 ### Step 3: Configure AI Agent
 
 Please add the following configuration for an AI Agent like Claude Desktop or Cline. 
-Insert the channel access token and user ID you obtained earlier into `CHANNEL_ACCESS_TOKEN` and `DESTINATION_USER_ID`, respectively. 
-Additionally, update the path to `line-bot-mcp-server` in  `mcpServers.args`.
+
+Set the environment variables or arguments as follows:
+- `mcpServers.args`: (required) The path to `line-bot-mcp-server`.
+- `CHANNEL_ACCESS_TOKEN`: (required) Channel Access Token. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/basics/channel-access-token/#long-lived-channel-access-token).
+- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
 
 #### Option 1: Use Node
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cd line-bot-mcp-server && npm install && npm run build
 
 ### Step 2: Create LINE Official Account
 
-This MCP server utilizes a LINE Official Account. If you do not have one, please create it by following [this instructions](https://www.linebiz.com/jp-en/manual/OfficialAccountManager/new_account/).
+This MCP server utilizes a LINE Official Account. If you do not have one, please create it by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-started/).
 
 ### Step 3: Configure AI Agent
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ const server = new McpServer({
 });
 
 const channelAccessToken = process.env.CHANNEL_ACCESS_TOKEN || "";
-const destinationId = process.env.DESTINATION_USER_ID || "";
+const destinationId = process.env.DESTINATION_USER_ID;
 
 const messagingApiClient = new line.messagingApi.MessagingApiClient({
   channelAccessToken: channelAccessToken,
@@ -54,8 +54,21 @@ server.tool(
     }),
   },
   async ({ userId, message }) => {
+    const to = userId ?? destinationId
+    if (!to) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "Error: Specify the userId or set the DESTINATION_USER_ID in the environment variables of this MCP Server.",
+          },
+        ],
+      };
+    }
+
     const response = await messagingApiClient.pushMessage({
-      to: userId ?? destinationId,
+      to: to,
       messages: [message as unknown as line.messagingApi.FlexMessage],
     });
     return {
@@ -104,8 +117,21 @@ server.tool(
     }),
   },
   async ({ userId, message }) => {
+    const to = userId ?? destinationId
+    if (!to) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "Error: Specify the userId or set the DESTINATION_USER_ID in the environment variables of this MCP Server.",
+          },
+        ],
+      };
+    }
+
     const response = await messagingApiClient.pushMessage({
-      to: userId ?? destinationId,
+      to: to,
       messages: [message as unknown as line.messagingApi.FlexMessage],
     });
     return {
@@ -131,8 +157,21 @@ server.tool(
       ),
   },
   async ({ userId }) => {
+    const targetUserId = userId ?? destinationId
+    if (!targetUserId) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "Error: Specify the userId or set the DESTINATION_USER_ID in the environment variables of this MCP Server.",
+          },
+        ],
+      };
+    }
+
     const response = await messagingApiClient.getProfile(
-      userId ?? destinationId,
+      targetUserId,
     );
     return {
       content: [
@@ -148,11 +187,6 @@ server.tool(
 async function main() {
   if (!process.env.CHANNEL_ACCESS_TOKEN) {
     console.error("Please set CHANNEL_ACCESS_TOKEN");
-    process.exit(1);
-  }
-
-  if (!process.env.DESTINATION_USER_ID) {
-    console.error("Please set DESTINATION_USER_ID");
     process.exit(1);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,6 @@ function createSuccessResponse(response: object) {
 
 const userIdSchema = z
   .string()
-  .optional()
   .default(destinationId)
   .describe(
     "The user ID to receive a message. Defaults to DESTINATION_USER_ID.",


### PR DESCRIPTION
Resolve #21 

I have added a tool for broadcasting. Along with this, I have refactored the common parts (the tool's schema). Additionally, the environment variable DESTINATION_USER_ID is now nullable. 

With these tools, you can broadcast messages to all followers. In addition, for use cases where you have few followers, such as just yourself or a limited users, you can use these tools instead of push_text_message or push_flex_message. This allows you to send messages without needing to prepare user IDs, simplifying the setup process. It is useful if you want to casually try out this MCP server.

Examples:
<img width="980" alt="スクリーンショット 2025-04-16 2 14 46" src="https://github.com/user-attachments/assets/e3c4bdbb-ee7d-4146-b9cd-bb80de8e5247" />
<img width="980" alt="スクリーンショット 2025-04-16 2 16 01" src="https://github.com/user-attachments/assets/486e7811-db68-4b8d-9809-cdd52cdc7909" />

