### PR TITLE
Add release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: line-openapi updates
+      labels:
+        - line-openapi-update
+    - title: New Features
+      labels:
+        - new-features
+    - title: Bug fix
+      labels:
+        - bug-fix
+    - title: Dependency updates
+      labels:
+        - dependency upgrade
+      exclude:
+        labels:
+          - line-openapi-update
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/scripts/update-version.mjs
+++ b/.github/scripts/update-version.mjs
@@ -1,0 +1,83 @@
+import fs from 'fs/promises';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+async function updateVersion(newVersion) {
+  // Files having version number
+  const files = {
+    packageJson: './package.json',
+    packageLockJson: './package-lock.json',
+  };
+
+  // package.json
+  const packageJsonData = JSON.parse(await fs.readFile(files.packageJson, 'utf8'));
+  packageJsonData.version = newVersion;
+  await fs.writeFile(files.packageJson, JSON.stringify(packageJsonData, null, 2) + '\n');
+
+  // package-lock.json
+  const packageLockJsonData = JSON.parse(await fs.readFile(files.packageLockJson, 'utf8'));
+  packageLockJsonData.version = newVersion;
+  if (packageLockJsonData.packages && packageLockJsonData.packages[""]) {
+    packageLockJsonData.packages[""].version = newVersion;
+  }
+  await fs.writeFile(files.packageLockJson, JSON.stringify(packageLockJsonData, null, 2) + '\n');
+}
+
+async function verifyVersion(expectedVersion) {
+  // package.json
+  const packageJsonData = JSON.parse(await fs.readFile('./package.json', 'utf8'));
+  if (packageJsonData.version !== expectedVersion) {
+    throw new Error(`package.json version mismatch: expected ${expectedVersion}, found ${packageJsonData.version}`);
+  }
+
+  // package-lock.json
+  const packageLockJsonData = JSON.parse(await fs.readFile('./package-lock.json', 'utf8'));
+  if (packageLockJsonData.version !== expectedVersion) {
+    throw new Error(`package-lock.json version mismatch: expected ${expectedVersion}, found ${packageLockJsonData.version}`);
+  }
+  if (packageLockJsonData.packages && packageLockJsonData.packages[""] && packageLockJsonData.packages[""].version !== expectedVersion) {
+    throw new Error(`package-lock.json root package version mismatch: expected ${expectedVersion}, found ${packageLockJsonData.packages[""].version}`);
+  }
+
+  console.log(`All files have the correct version: ${expectedVersion}`);
+}
+
+async function verifyGitDiff() {
+  try {
+    const { stdout: numstatOutput } = await execAsync('git diff --numstat');
+    const { addedLines, deletedLines } = numstatOutput.trim().split('\n').reduce((acc, line) => {
+      const [added, deleted] = line.split('\t').map(Number);
+      acc.addedLines += added;
+      acc.deletedLines += deleted;
+      return acc;
+    }, { addedLines: 0, deletedLines: 0 });
+
+    if (addedLines !== 3 || deletedLines !== 3) {
+      throw new Error(`Unexpected number of changed lines: expected 4 added and 4 deleted, found ${addedLines} added and ${deletedLines} deleted`);
+    }
+
+    console.log('Git diff verification passed: 4 lines added and 4 lines deleted.');
+
+    // Display the diff with context and color
+    const { stdout: diffOutput } = await execAsync('git diff -U5 --color=always');
+    console.log('Git diff with context and color:\n', diffOutput);
+
+  } catch (error) {
+    console.error('Error during git diff verification:', error.message);
+    process.exit(1);
+  }
+}
+
+// Main process
+const args = process.argv.slice(2);
+if (args.length !== 1) {
+  console.error('Usage: node update-version.mjs <new-version>');
+  process.exit(1);
+}
+
+const newVersion = args[0];
+await updateVersion(newVersion);
+await verifyVersion(newVersion);
+await verifyGitDiff();

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -1,0 +1,133 @@
+name: Create Draft Release with Auto-Generated Notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Select the version type to increment (major, minor, patch)"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      release_title:
+        description: "Enter the title of the release"
+        required: true
+        type: string
+      acknowledge_draft:
+        description: "I understand that I must re-edit and finalize the draft release (Y/N)"
+        required: true
+        type: choice
+        options:
+          - "No"
+          - "Yes"
+
+jobs:
+  validate-input:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Validate Acknowledgement
+        if: ${{ github.event.inputs.acknowledge_draft != 'Yes' }}
+        run: |
+          echo "You must select 'Yes' to acknowledge your responsibility for finalizing the draft release."
+          exit 1
+      - name: Validate title (no empty)
+        if: ${{ github.event.inputs.release_title == '' }}
+        run: |
+          echo "You must enter a title for the release."
+          exit 1
+
+  create-draft-release:
+    runs-on: ubuntu-latest
+    needs: validate-input
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Fetch Latest Release
+        id: get-latest-release
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const latestRelease = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            }).catch(() => null);
+
+            if (latestRelease) {
+              core.setOutput('latest_tag', latestRelease.data.tag_name);
+            } else {
+              core.setOutput('latest_tag', 'v0.0.0'); // Default for first release
+            }
+
+      - name: Calculate New Version
+        id: calculate-version
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const latestTag = '${{ steps.get-latest-release.outputs.latest_tag }}';
+            const versionType = '${{ github.event.inputs.version_type }}';
+
+            const [major, minor, patch] = latestTag.replace('v', '').split('.').map(Number);
+
+            let newVersion;
+            if (versionType === 'major') {
+              newVersion = `v${major + 1}.0.0`;
+            } else if (versionType === 'minor') {
+              newVersion = `v${major}.${minor + 1}.0`;
+            } else {
+              newVersion = `v${major}.${minor}.${patch + 1}`;
+            }
+
+            core.setOutput('new_version', newVersion);
+
+      - name: Generate Release Notes
+        id: generate-release-notes
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { data: releaseNotes } = await github.rest.repos.generateReleaseNotes({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: "${{ steps.calculate-version.outputs.new_version }}"
+            });
+
+            const actor = context.actor;
+            const noteToAdd = `**@${actor} 👈 TODO: Write detailed release note for this version before release**\n`;
+
+            const footer = `---\nThis release is prepared by @${actor}`;
+
+            const modifiedBody = releaseNotes.body.replace(
+              '## What\'s Changed',
+              `## What's Changed\n\n${noteToAdd}`
+            )
+            .concat(`\n\n${footer}`);
+
+            console.log(`releaseNotes (modified): ${JSON.stringify(modifiedBody, null, 2)}`);
+            core.setOutput("release_body", modifiedBody);
+
+      - name: Prepare Release Title
+        id: title
+        env:
+          # "vX.Y.Z Release Title"
+          RAW_TITLE: ${{ steps.calculate-version.outputs.new_version }} ${{ github.event.inputs.release_title }}
+        run: |
+          # Print RAW_TITLE safely, then escape double quotes
+          SANITIZED_TITLE="$(printf '%s' "$RAW_TITLE" | sed 's/"/\\"/g')"
+          echo "sanitized_title=$SANITIZED_TITLE" >> "$GITHUB_OUTPUT"
+
+      - name: Write Release Notes to File
+        run: |
+          echo "${{ steps.generate-release-notes.outputs.release_body }}" > release-notes.txt
+
+      - name: Create Draft Release
+        run: |
+          gh release create "${{ steps.calculate-version.outputs.new_version }}" \
+            --title "${{ steps.title.outputs.sanitized_title }}" \
+            --notes-file release-notes.txt \
+            --draft \
+            --repo "${{ github.repository }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release Node.js Package
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to release'
+        required: true
+
+jobs:
+  release-package:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - name: Update version in package.json, package-lock.json, and lib/version.ts
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            VERSION=${{ github.event.inputs.version }}
+          else
+            VERSION=${{ github.event.release.tag_name }}
+          fi
+          VERSION=${VERSION#v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          node .github/scripts/update-version.mjs $VERSION
+      - run: npm run release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Issue on Failure
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const version = process.env.VERSION;
+            const issueTitle = `Release job for ${version} failed`;
+            const issueBody = `The release job failed. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`;
+            const assignees = [context.actor];
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: issueTitle,
+              body: issueBody,
+              assignees
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
-      - name: Update version in package.json, package-lock.json, and lib/version.ts
+      - name: Update version in package.json, package-lock.json
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             VERSION=${{ github.event.inputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+      - name: Install pnpm  # For publint
+        run: npm install -g pnpm
       - name: publint
         run: npx publint
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+      - name: publint
+        run: npx publint
 
   pinact:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -122,3 +122,13 @@ docker build -t line/line-bot-mcp-server .
   }
 }
 ```
+
+## Versioning
+
+This project respects semantic versioning
+
+See http://semver.org/
+
+## Contributing
+
+Please check [CONTRIBUTING](./CONTRIBUTING.md) before making a contribution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "@modelcontextprotocol/sdk": "^1.8.0",
         "zod": "^3.24.2"
       },
+      "bin": {
+        "line-bot-mcp-server": "dist/index.js"
+      },
       "devDependencies": {
         "@types/node": "^22",
         "prettier": "3.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@line/line-bot-mcp-server",
-  "version": "0.0.1",
+  "version": "0.0.1-local",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@line/line-bot-mcp-server",
-      "version": "0.0.1",
+      "version": "0.0.1-local",
       "license": "Apache-2.0",
       "dependencies": {
         "@line/bot-sdk": "^9.8.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "format": "npm run prettier -- --write",
     "format:check": "npm run prettier -- -l",
     "clean": "rm -rf dist/*",
-    "prebuild": "npm run format:check && npm run clean"
+    "prebuild": "npm run format:check && npm run clean",
+    "release": "npm run build && npm publish --provenance --access public"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "files": [
     "dist"
   ],
-  "main": "src/index.ts",
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",
     "prettier": "prettier \"src/**/*.ts\"",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "node": ">=20"
   },
   "module": "./dist/index.js",
+  "bin": {
+    "line-bot-mcp-server": "./dist/index.js"
+  },
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line/line-bot-mcp-server",
-  "version": "0.0.1",
+  "version": "0.0.1-local",
   "description": "MCP server for interacting with your LINE Official Account",
   "type": "module",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * Copyright 2025 LY Corporation
  *


### PR DESCRIPTION
 Related to #9 

Publish this repository as an npm package.
By doing so, users can start the MCP Server simply by running a command like npx @line/line-bot-mcp-server, without needing to clone and build the repository locally. This will lower the barrier to using this MCP Server.

The secret (NPM_TOKEN) is already set.
In addition, README.md will be updated after publish this package to be descripted how to use this by npx.
