### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,57 +36,33 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
    - **Inputs:**
       - `user_id` (string?): プロフィールを取得したいユーザーのユーザーID。デフォルトはDESTINATION_USER_ID。
 
-## インストール
-
-### Step 1: line-bot-mcp-serverをインストール
+## インストール (npxを使用)
 
 要件:
 - Node.js v20 以上
 
-このリポジトリをクローンします:
-
-```
-git clone git@github.com:line/line-bot-mcp-server.git
-```
-
-Node.jsを利用する場合は、必要な依存関係をインストールし、line-bot-mcp-serverをビルドします。Dockerを利用する場合は不要です。:
-
-```
-cd line-bot-mcp-server && npm install && npm run build
-```
-
-
-### Step 2: LINE公式アカウントを作成
+### Step 1: LINE公式アカウントを作成
 
 このMCP ServerはLINE公式アカウントを利用しています。公式アカウントをお持ちでない場合は、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-started/#create-oa)に従って作成してください。
 
 LINE公式アカウントをお持ちであれば、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-started/#using-oa-manager)に従ってMessaging APIを有効にしてください。
 
-### Step 3: AI Agentを設定
+### Step 2: AI Agentを設定
 
 Claude DesktopやClaudeなどのAI Agentに次の設定を追加してください。
 
 環境変数や引数は次のように設定してください:
 
-- `mcpServers.args`: (必須) `line-bot-mcp-server`へのパス。
 - `CHANNEL_ACCESS_TOKEN`: (必須) チャネルアクセストークン。これを取得するには、[こちらの手順](https://developers.line.biz/ja/docs/basics/channel-access-token/#long-lived-channel-access-token)に従ってください。
 - `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
-
-### Step 3: AI Agentを設定
-
-Claude DesktopやClaudeなどのAI Agentに次の設定を追加してください。
-`CHANNEL_ACCESS_TOKEN`と`DESTINATION_USER_ID`には、先ほど取得したチャネルアクセストークンとユーザーIDをそれぞれ挿入してください。
-加えて、`mcpServers.args`にある`line-bot-mcp-server`へのパスを更新してください。
-
-#### Option 1: Node.jsを利用する場合
 
 ```json
 {
   "mcpServers": {
     "line-bot": {
-      "command": "node",
+      "command": "npx",
       "args": [
-        "PATH/TO/line-bot-mcp-server/dist/index.js"
+        "@line/line-bot-mcp-server"
       ],
       "env": {
         "CHANNEL_ACCESS_TOKEN" : "FILL_HERE",
@@ -97,14 +73,36 @@ Claude DesktopやClaudeなどのAI Agentに次の設定を追加してくださ�
 }
 ```
 
-#### Option 2: Dockerを利用する場合
+## インストール (Dockerを使用)
 
-まずDockerイメージをビルドします:
+### Step 1: LINE公式アカウントを作成
+
+このMCP ServerはLINE公式アカウントを利用しています。公式アカウントをお持ちでない場合は、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-started/#create-oa)に従って作成してください。
+
+LINE公式アカウントをお持ちであれば、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-started/#using-oa-manager)に従ってMessaging APIを有効にしてください。
+
+### Step 2: line-bot-mcp-serverをインストール
+
+このリポジトリをクローンします:
+
+```
+git clone git@github.com:line/line-bot-mcp-server.git
+```
+
+Dockerイメージをビルドします:
 ```
 docker build -t line/line-bot-mcp-server .
 ```
 
-次のように設定します:
+### Step 3: AI Agentを設定
+
+Claude DesktopやClaudeなどのAI Agentに次の設定を追加してください。
+
+環境変数や引数は次のように設定してください:
+
+- `mcpServers.args`: (必須) `line-bot-mcp-server`へのパス。
+- `CHANNEL_ACCESS_TOKEN`: (必須) チャネルアクセストークン。これを取得するには、[こちらの手順](https://developers.line.biz/ja/docs/basics/channel-access-token/#long-lived-channel-access-token)に従ってください。
+- `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
 
 ```json
 {

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,7 @@
 # LINE Bot MCP Server
 
+[![npmjs](https://badge.fury.io/js/%40line%2Fline-bot-mcp-server.svg)](https://www.npmjs.com/package/@line/line-bot-mcp-server)
+
 LINE公式アカウントとAI Agentを接続するために、LINE Messaging APIを統合する[Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) Server
 
 ![](/assets/demo.ja.png)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # LINE Bot MCP Server
 
+[![npmjs](https://badge.fury.io/js/%40line%2Fline-bot-mcp-server.svg)](https://www.npmjs.com/package/@line/line-bot-mcp-server)
+
 [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) server implementation that integrates the LINE Messaging API to connect an AI Agent to the LINE Official Account.
 
 ![](/assets/demo.png)

--- a/README.md
+++ b/README.md
@@ -39,49 +39,33 @@
      - `user_id` (string?): The ID of the user whose profile you want to retrieve. Defaults to DESTINATION_USER_ID.
 
 
-## Installation
-
-### Step 1: Install line-bot-mcp-server
+## Installation (Using npx)
 
 requirements:
 - Node.js v20 or later
 
-Clone this repository:
-
-```
-git clone git@github.com:line/line-bot-mcp-server.git
-```
-
-Install the necessary dependencies and build line-bot-mcp-server when using Node.js. This step is not required when using Docker:
-
-```
-cd line-bot-mcp-server && npm install && npm run build
-```
-
-### Step 2: Create LINE Official Account
+### Step 1: Create LINE Official Account
 
 This MCP server utilizes a LINE Official Account. If you do not have one, please create it by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-started/#create-oa). 
 
 If you have a LINE Official Account, enable the Messaging API for your LINE Official Account by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-started/#using-oa-manager).
 
-### Step 3: Configure AI Agent
+### Step 2: Configure AI Agent
 
 Please add the following configuration for an AI Agent like Claude Desktop or Cline. 
 
 Set the environment variables or arguments as follows:
-- `mcpServers.args`: (required) The path to `line-bot-mcp-server`.
+
 - `CHANNEL_ACCESS_TOKEN`: (required) Channel Access Token. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/basics/channel-access-token/#long-lived-channel-access-token).
 - `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
-
-#### Option 1: Use Node
 
 ```json
 {
   "mcpServers": {
     "line-bot": {
-      "command": "node",
+      "command": "npx",
       "args": [
-        "PATH/TO/line-bot-mcp-server/dist/index.js"
+        "@line/line-bot-mcp-server"
       ],
       "env": {
         "CHANNEL_ACCESS_TOKEN" : "FILL_HERE",
@@ -92,12 +76,39 @@ Set the environment variables or arguments as follows:
 }
 ```
 
-#### Option 2: Use Docker
+## Installation (Using Docker)
 
-Build the Docker image first:
+### Step 1: Create LINE Official Account
+
+This MCP server utilizes a LINE Official Account. If you do not have one, please create it by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-started/#create-oa).
+
+If you have a LINE Official Account, enable the Messaging API for your LINE Official Account by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-started/#using-oa-manager).
+
+
+### Step 2: Build line-bot-mcp-server image
+
+Clone this repository:
+
+```
+git clone git@github.com:line/line-bot-mcp-server.git
+```
+
+Build the Docker image:
+
 ```
 docker build -t line/line-bot-mcp-server .
 ```
+
+### Step 3: Configure AI Agent
+
+Please add the following configuration for an AI Agent like Claude Desktop or Cline.
+
+Set the environment variables or arguments as follows:
+
+- `mcpServers.args`: (required) The path to `line-bot-mcp-server`.
+- `CHANNEL_ACCESS_TOKEN`: (required) Channel Access Token. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/basics/channel-access-token/#long-lived-channel-access-token).
+- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
+
 
 ```json
 {


### PR DESCRIPTION
Resolve #9 

We have published line-bot-mcp-server as an npm package. 
https://www.npmjs.com/package/@line/line-bot-mcp-server?activeTab=readme

Therefore, you can start this MCP Server using the npx command. I have documented this procedure in the README and organized it.