### PR TITLE
feat: clarifying the descriptions of user_id and DESTINATION_USER_ID …

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -35,7 +35,7 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
      - `message.contents.type` (enum): コンテナのタイプ。'bubble'は単一コンテナ、'carousel'は複数のスワイプ可能なバブルを示す。
 5. **get_profile**
    - LINEユーザーの詳細なプロフィール情報を取得する。表示名、プロフィール画像URL、ステータスメッセージ、言語を取得できる。
-   - **Inputs:**
+   - **入力:**
       - `user_id` (string?): プロフィールを取得したいユーザーのユーザーID。デフォルトはDESTINATION_USER_ID。`user_id`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。
 
 ## インストール (npxを使用)
@@ -56,7 +56,7 @@ Claude DesktopやClaudeなどのAI Agentに次の設定を追加してくださ�
 環境変数や引数は次のように設定してください:
 
 - `CHANNEL_ACCESS_TOKEN`: (必須) チャネルアクセストークン。これを取得するには、[こちらの手順](https://developers.line.biz/ja/docs/basics/channel-access-token/#long-lived-channel-access-token)に従ってください。
-- `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。Toolの入力に`user_id`が含まれる場合、`user_id`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
+- `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。Toolの入力に`user_id`が含まれていない場合、`DESTINATION_USER_ID`は必ず設定する必要があります。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
 
 ```json
 {
@@ -104,7 +104,7 @@ Claude DesktopやClaudeなどのAI Agentに次の設定を追加してくださ�
 
 - `mcpServers.args`: (必須) `line-bot-mcp-server`へのパス。
 - `CHANNEL_ACCESS_TOKEN`: (必須) チャネルアクセストークン。これを取得するには、[こちらの手順](https://developers.line.biz/ja/docs/basics/channel-access-token/#long-lived-channel-access-token)に従ってください。
-- `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
+- `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。Toolの入力に`user_id`が含まれていない場合、`DESTINATION_USER_ID`は必ず設定する必要があります。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
 
 ```json
 {

--- a/README.ja.md
+++ b/README.ja.md
@@ -12,12 +12,12 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
 1. **push_text_message**
    - LINEでユーザーにシンプルなテキストメッセージを送信する。
    - **入力:**
-     - `user_id` (string?): メッセージ受信者のユーザーID。デフォルトはDESTINATION_USER_ID。
+     - `user_id` (string?): メッセージ受信者のユーザーID。デフォルトはDESTINATION_USER_ID。`user_id`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。
      - `message.text` (string): ユーザーに送信するテキスト。
 2. **push_flex_message**
    - LINEでユーザーに高度にカスタマイズ可能なフレックスメッセージを送信する。
    - **入力:**
-     - `user_id` (string?): メッセージ受信者のユーザーID。デフォルトはDESTINATION_USER_ID。
+     - `user_id` (string?): メッセージ受信者のユーザーID。デフォルトはDESTINATION_USER_ID。`user_id`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。
      - `message.altText` (string): フレックスメッセージが表示できない場合に表示される代替テキスト。
      - `message.content` (any): フレックスメッセージの内容。メッセージのレイアウトとコンポーネントを定義するJSONオブジェクト。
      - `message.contents.type` (enum): コンテナのタイプ。'bubble'は単一コンテナ、'carousel'は複数のスワイプ可能なバブルを示す。
@@ -34,7 +34,7 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
 5. **get_profile**
    - LINEユーザーの詳細なプロフィール情報を取得する。表示名、プロフィール画像URL、ステータスメッセージ、言語を取得できる。
    - **Inputs:**
-      - `user_id` (string?): プロフィールを取得したいユーザーのユーザーID。デフォルトはDESTINATION_USER_ID。
+      - `user_id` (string?): プロフィールを取得したいユーザーのユーザーID。デフォルトはDESTINATION_USER_ID。`user_id`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。
 
 ## インストール
 
@@ -70,7 +70,7 @@ Claude DesktopやClaudeなどのAI Agentに次の設定を追加してくださ�
 
 - `mcpServers.args`: (必須) `line-bot-mcp-server`へのパス。
 - `CHANNEL_ACCESS_TOKEN`: (必須) チャネルアクセストークン。これを取得するには、[こちらの手順](https://developers.line.biz/ja/docs/basics/channel-access-token/#long-lived-channel-access-token)に従ってください。
-- `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
+- `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。`user_id`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
 
 ### Step 3: AI Agentを設定
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -56,7 +56,7 @@ Claude DesktopやClaudeなどのAI Agentに次の設定を追加してくださ�
 環境変数や引数は次のように設定してください:
 
 - `CHANNEL_ACCESS_TOKEN`: (必須) チャネルアクセストークン。これを取得するには、[こちらの手順](https://developers.line.biz/ja/docs/basics/channel-access-token/#long-lived-channel-access-token)に従ってください。
-- `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。`user_id`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
+- `DESTINATION_USER_ID`: (オプション) デフォルトのメッセージ受信者のユーザーID。Toolの入力に`user_id`が含まれる場合、`user_id`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。これを確認するには、[こちらの手順](https://developers.line.biz/ja/docs/messaging-api/getting-user-ids/#get-own-user-id)に従ってください。
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please add the following configuration for an AI Agent like Claude Desktop or Cl
 Set the environment variables or arguments as follows:
 
 - `CHANNEL_ACCESS_TOKEN`: (required) Channel Access Token. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/basics/channel-access-token/#long-lived-channel-access-token).
-- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. Either `user_id` or `DESTINATION_USER_ID` must be set. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
+- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. If the Tool's input includes user_id, either `user_id` or `DESTINATION_USER_ID` must be set. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please add the following configuration for an AI Agent like Claude Desktop or Cl
 Set the environment variables or arguments as follows:
 
 - `CHANNEL_ACCESS_TOKEN`: (required) Channel Access Token. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/basics/channel-access-token/#long-lived-channel-access-token).
-- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. If the Tool's input includes user_id, either `user_id` or `DESTINATION_USER_ID` must be set. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
+- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. If the Tool's input does not include `user_id`, `DESTINATION_USER_ID` is required. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
 
 ```json
 {
@@ -109,7 +109,8 @@ Set the environment variables or arguments as follows:
 
 - `mcpServers.args`: (required) The path to `line-bot-mcp-server`.
 - `CHANNEL_ACCESS_TOKEN`: (required) Channel Access Token. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/basics/channel-access-token/#long-lived-channel-access-token).
-- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
+- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. If the Tool's input does not include `user_id`, `DESTINATION_USER_ID` is required.
+You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
 
 
 ```json

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Please add the following configuration for an AI Agent like Claude Desktop or Cl
 Set the environment variables or arguments as follows:
 - `mcpServers.args`: (required) The path to `line-bot-mcp-server`.
 - `CHANNEL_ACCESS_TOKEN`: (required) Channel Access Token. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/basics/channel-access-token/#long-lived-channel-access-token).
-- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. Either `user_id` or `DESTINATION_USER_ID` must be set.You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
+- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. Either `user_id` or `DESTINATION_USER_ID` must be set. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
 
 #### Option 1: Use Node
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@
 1. **push_text_message**
    - Push a simple text message to a user via LINE.
    - **Inputs:**
-     - `user_id` (string?): The user ID to receive a message. Defaults to DESTINATION_USER_ID.
+     - `user_id` (string?): The user ID to receive a message. Defaults to DESTINATION_USER_ID. Either `user_id` or `DESTINATION_USER_ID` must be set.
      - `message.text` (string): The plain text content to send to the user.
 2. **push_flex_message**
    - Push a highly customizable flex message to a user via LINE.
    - **Inputs:**
-     - `user_id` (string?): The user ID to receive a message. Defaults to DESTINATION_USER_ID.
+     - `user_id` (string?): The user ID to receive a message. Defaults to DESTINATION_USER_ID. Either `user_id` or `DESTINATION_USER_ID` must be set.
      - `message.altText` (string): Alternative text shown when flex message cannot be displayed.
      - `message.content` (any): The content of the flex message. This is a JSON object that defines the layout and components of the message.
      - `message.contents.type` (enum): Type of the container. 'bubble' for single container, 'carousel' for multiple swipeable bubbles.
@@ -71,7 +71,7 @@ Please add the following configuration for an AI Agent like Claude Desktop or Cl
 Set the environment variables or arguments as follows:
 - `mcpServers.args`: (required) The path to `line-bot-mcp-server`.
 - `CHANNEL_ACCESS_TOKEN`: (required) Channel Access Token. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/basics/channel-access-token/#long-lived-channel-access-token).
-- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
+- `DESTINATION_USER_ID`: (optional) The default user ID of the recipient. Either `user_id` or `DESTINATION_USER_ID` must be set.You can confirm this by following [this instructions](https://developers.line.biz/en/docs/messaging-api/getting-user-ids/#get-own-user-id).
 
 #### Option 1: Use Node
 


### PR DESCRIPTION
Resolve this [issue](https://github.com/line/line-bot-mcp-server/issues/48)

This pull request updates the documentation in both Japanese (`README.ja.md`) and English (`README.md`) to clarify the requirements for setting `user_id` and `DESTINATION_USER_ID` in various contexts. The changes ensure that users understand that at least one of these values must be specified.

### Documentation Updates:

#### Clarifications on `user_id` and `DESTINATION_USER_ID` Requirements:
* Updated descriptions in the `push_text_message`, `push_flex_message`, and `get_profile` sections to specify that either `user_id` or `DESTINATION_USER_ID` must be set. (`README.ja.md`: [[1]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L15-R20) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L37-R37); `README.md`: [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R22)
* Modified the description of the `DESTINATION_USER_ID` environment variable to clarify that it is optional but either it or `user_id` must be set. (`README.ja.md`: [[1]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L73-R73); `README.md`: [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R74)