### PR TITLE
Add version.ts instead of importing package.json in source code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,14 +20,14 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import * as line from "@line/bot-sdk";
 import { z } from "zod";
-import pkg from "../package.json" with { type: "json" };
+import { LINE_BOT_MCP_SERVER_VERSION, USER_AGENT } from "./version.js";
 
 const NO_USER_ID_ERROR =
   "Error: Specify the userId or set the DESTINATION_USER_ID in the environment variables of this MCP Server.";
 
 const server = new McpServer({
   name: "line-bot",
-  version: pkg.version,
+  version: LINE_BOT_MCP_SERVER_VERSION,
 });
 
 const channelAccessToken = process.env.CHANNEL_ACCESS_TOKEN || "";
@@ -36,7 +36,7 @@ const destinationId = process.env.DESTINATION_USER_ID || "";
 const messagingApiClient = new line.messagingApi.MessagingApiClient({
   channelAccessToken: channelAccessToken,
   defaultHeaders: {
-    "User-Agent": `${pkg.name}/${pkg.version}`,
+    "User-Agent": USER_AGENT,
   },
 });
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,2 @@
+export const LINE_BOT_MCP_SERVER_VERSION = "0.1.0-local";
+export const USER_AGENT = `@line/line-bot-mcp-server/${LINE_BOT_MCP_SERVER_VERSION}`;


### PR DESCRIPTION
The `with` syntax in import pkg from "../package.json" with { type: "json" }; has been available since Node v20.10. On the other hand, the older `assert` syntax in import pkg from "../package.json" assert { type: "json" }; cannot be used in Node v22 or later. Therefore, there is no way to support both v20.9 and below, and v22 and above at the same time. 

Since we want to support both versions in line-bot-mcp-server, we decided to stop importing package.json directly. Instead, version.ts is now used.

The version in version.ts is automatically updated by GitHub Actions at release.




