### PR TITLE
Fix wrong markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@
    - **Inputs:**
      - `user_id` (string?): The ID of the user whose profile you want to retrieve. Defaults to DESTINATION_USER_ID.
 6. **get_message_quota**
-  - Get the message quota and consumption of the LINE Official Account. This shows the monthly message limit and current usage.
-  - **Inputs:**
+   - Get the message quota and consumption of the LINE Official Account. This shows the monthly message limit and current usage.
+   - **Inputs:**
      - None
 
 ## Installation (Using npx)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 6. **get_message_quota**
   - Get the message quota and consumption of the LINE Official Account. This shows the monthly message limit and current usage.
   - **Inputs:**
-    - None
+     - None
 
 ## Installation (Using npx)
 


### PR DESCRIPTION
Fix trivial points in https://github.com/line/line-bot-mcp-server/pull/44.
README.jp.md is correct, but README.md is not. This change just fixes its syntax. 
