### PR TITLE
Improve issue triage and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,37 +1,40 @@
 ---
-name: Bug report
-about: Create a report to help us improve
-title: '[BUG]'
-labels: 'bug'
-assignees: ''
-
+name: Bug Report Template
+about: Use this template to report bugs in the line-bot-sdk-ruby
+title: 'Bug Report'
 ---
 
 ## Bug Report
-<!-- First of all: Have you checked the docs https://developers.line.biz/en/docs/messaging-api/overview/, Q&A page https://developers.line.biz/en/faq/, https://www.line-community.me/questions, GitHub issues whether someone else has already reported your issue? -->
+ <!--
+## Before Creating an Issue
+- Please check our [developer documentation](https://developers.line.biz/en/docs/) and [FAQ](https://developers.line.biz/en/faq/tags/messaging-api/) for more information on the Messaging API
+- Make sure the issue you are reporting isn't already addressed in the documentation or existing issues.
+## When Creating an Issue
+- Provide detailed information about the issue you experienced with the MCP Server using the template below.
+-->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
-
-**To Reproduce**
-<!-- It would be appreciate if you share the minimal complete reproducible Javascript code or Repo link: -->
-Steps to reproduce the behavior:
-1. use '...' function, pass the '...' parameter.
-2. ...
-3. ???
-4. See error
-
-**Expected behavior**
-A clear and concise description of what you expected to happen.
-
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Environment (please complete the following information):**
+## System Information
  - OS: [e.g. Ubuntu]
  - Node.js Version [e.g. Node 22]
  - line-bot-mcp-server version(s) [e.g. 0.0.1]
  - AI Agent you use [e.g. Claude for Desktop]
 
-**Additional context**
-Add any other context about the problem here.
+## Expected Behavior
+<!-- Describe what you expected to happen -->
+
+## Current Behavior
+<!-- Describe what actually happened instead of the expected behavior -->
+
+## Steps to Reproduce
+<!-- Provide a link to a live example or a clear set of steps to reproduce the issue.
+     If possible, provide minimal code (e.g. test code, a draft PR, or a link to a forked repository) or prompt. -->
+1.
+2.
+3.
+
+## Logs
+<!-- If possible, provide logs to help identify the issue -->
+
+## Additional Context (Optional)
+<!-- Add any other context or information that might be relevant to the issue.
+     For example, related issues, potential causes, or possible solutions. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report Template
-about: Use this template to report bugs in the line-bot-sdk-ruby
+about: Use this template to report bugs in the line-bot-mcp-server
 title: 'Bug Report'
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[Feature Request]"
-labels: enhancement
-assignees: ''
-
+title: "Feature Request"
 ---
 
 ## Feature Request

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,42 @@
+---
+name: "Question Template"
+about: "Use this template to ask questions about usage or implementation of the line-bot-mcp-server."
+title: "Question"
+---
+
+<!--
+## Before Creating a Question Issue
+- Please check the [developer documentation](https://developers.line.biz/en/docs/) and [FAQ](https://developers.line.biz/en/faq/tags/messaging-api/) for answers to common questions.
+- Make sure your question hasn't already been asked in other Issues or the documentation.
+## This Is Not
+- A bug report. If you think you've found a bug, please use the "Bug Report" template.
+- A place to request new features. If you have a feature request, consider opening a "Feature Request" issue or PR.
+## When Creating a Question
+- Provide detailed information about your environment and context so we can better understand and answer your question.
+- Let us know what you've tried so far (e.g. searching docs, existing issues, etc.).
+-->
+
+## Have You Checked the Following?
+- [ ] [Developer Documentation - LINE Developers](https://developers.line.biz/en/docs/)
+- [ ] [FAQ - LINE Developers](https://developers.line.biz/en/faq/tags/messaging-api/)
+
+## Summary of Your Question
+<!-- Provide a clear and concise description of what you want to know. -->
+
+## Details
+<!-- Provide any prompt, code snippets, relevant logs, or background details that will help us understand your question better. -->
+
+## What You've Tried
+<!-- Let us know any steps you've already taken to answer your own question, 
+     such as searching in documentation or checking existing issues. -->
+
+## Your Environment
+<!-- For example:
+ - OS: [e.g. Ubuntu]
+ - Node.js Version [e.g. Node 22]
+ - line-bot-mcp-server version(s) [e.g. 0.0.1]
+ - AI Agent you use [e.g. Claude for Desktop]
+-->
+
+## Additional Context (Optional)
+<!-- Add any other context, possible considerations, or related links here. -->

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -20,7 +20,7 @@ jobs:
           days-before-issue-close: 0
           stale-issue-label: "no-activity"
           close-issue-message: "This issue was closed because it has been inactive for 28 days."
-          exempt-issue-labels: "bug,enhancement,keep"
+          exempt-issue-labels: "bug,enhancement,keep,untriaged"
           days-before-pr-stale: -1
           days-before-pr-close: 28
           stale-pr-label: "no-activity"

--- a/.github/workflows/label-issue.yml
+++ b/.github/workflows/label-issue.yml
@@ -1,0 +1,32 @@
+name: Label issue
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - closed
+
+jobs:
+  label-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Add label on issue open
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --add-label "untriaged" \
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Remove label on issue close
+        if: github.event.action == 'closed'
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --remove-label "untriaged"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This change modifies the issue template for bug reports and adds an issue template for inquiries.

Additionally, issues now always have the `untriaged` label set, and they won't be closed until a maintainer removes the label.


## minor tasks
- [x] add `untriaged` label in this repository

FYI https://github.com/line/line-bot-sdk-ruby/pull/597