### PR TITLE
Add rich menu apis

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,11 +36,33 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
 5. **get_profile**
    - LINEユーザーの詳細なプロフィール情報を取得する。表示名、プロフィール画像URL、ステータスメッセージ、言語を取得できる。
    - **入力:**
-      - `user_id` (string?): プロフィールを取得したいユーザーのユーザーID。デフォルトはDESTINATION_USER_ID。`user_id`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。=======
+      - `user_id` (string?): プロフィールを取得したいユーザーのユーザーID。デフォルトはDESTINATION_USER_ID。`user_id`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。
 6. **get_message_quota**
    - LINE公式アカウントのメッセージ容量と消費量を取得します。月間メッセージ制限と現在の使用量が表示されます。
    - **入力:**
      - なし
+7. **get_rich_menu_list**
+   - LINE公式アカウントに登録されているリッチメニューの一覧を取得する。
+   - **入力:**
+     - なし
+8. **delete_rich_menu**
+   - LINE公式アカウントからリッチメニューを削除する。
+   - **入力:**
+     - `richMenuId` (string): 削除するリッチメニューのID。
+9. **set_rich_menu_image**
+   - LINE公式アカウントのリッチメニューの画像を更新する。
+   - **入力:**
+     - `richMenuId` (string): 更新するリッチメニューのID。
+     - `projectPath` (string): プロジェクトのパス。
+     - `imagePath` (string): 更新する画像のパス。`@`プレフィックスを使用してプロジェクトルートからの相対パスを指定できます。
+10. **set_rich_menu_default**
+    - リッチメニューをデフォルトとして設定する。
+    - **入力:**
+      - `richMenuId` (string): デフォルトとして設定するリッチメニューのID。
+11. **cancel_rich_menu_default**
+    - デフォルトのリッチメニューを解除する。
+    - **入力:**
+      - なし
 
 ## インストール (npxを使用)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -49,17 +49,11 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
    - LINE公式アカウントからリッチメニューを削除する。
    - **入力:**
      - `richMenuId` (string): 削除するリッチメニューのID。
-9. **set_rich_menu_image**
-   - LINE公式アカウントのリッチメニューの画像を更新する。
-   - **入力:**
-     - `richMenuId` (string): 更新するリッチメニューのID。
-     - `projectPath` (string): プロジェクトのパス。
-     - `imagePath` (string): 更新する画像のパス。`@`プレフィックスを使用してプロジェクトルートからの相対パスを指定できます。
-10. **set_rich_menu_default**
+9. **set_rich_menu_default**
     - リッチメニューをデフォルトとして設定する。
     - **入力:**
       - `richMenuId` (string): デフォルトとして設定するリッチメニューのID。
-11. **cancel_rich_menu_default**
+10. **cancel_rich_menu_default**
     - デフォルトのリッチメニューを解除する。
     - **入力:**
       - なし

--- a/README.md
+++ b/README.md
@@ -43,6 +43,28 @@
    - Get the message quota and consumption of the LINE Official Account. This shows the monthly message limit and current usage.
    - **Inputs:**
      - None
+7. **get_rich_menu_list**
+   - Get the list of rich menus associated with your LINE Official Account.
+   - **Inputs:**
+     - None
+8. **delete_rich_menu**
+   - Delete a rich menu from your LINE Official Account.
+   - **Inputs:**
+     - `richMenuId` (string): The ID of the rich menu to delete.
+9. **set_rich_menu_image**
+   - Update a rich menu associated with your LINE Official Account.
+   - **Inputs:**
+     - `richMenuId` (string): The ID of the rich menu to update.
+     - `projectPath` (string): The path of the project.
+     - `imagePath` (string): The path of the image to update. Use `@` prefix to specify a path relative to the project root.
+10. **set_rich_menu_default**
+    - Set a rich menu as the default rich menu.
+    - **Inputs:**
+      - `richMenuId` (string): The ID of the rich menu to set as default.
+11. **cancel_rich_menu_default**
+    - Cancel the default rich menu.
+    - **Inputs:**
+      - None
 
 ## Installation (Using npx)
 

--- a/README.md
+++ b/README.md
@@ -51,17 +51,11 @@
    - Delete a rich menu from your LINE Official Account.
    - **Inputs:**
      - `richMenuId` (string): The ID of the rich menu to delete.
-9. **set_rich_menu_image**
-   - Update a rich menu associated with your LINE Official Account.
-   - **Inputs:**
-     - `richMenuId` (string): The ID of the rich menu to update.
-     - `projectPath` (string): The path of the project.
-     - `imagePath` (string): The path of the image to update. Use `@` prefix to specify a path relative to the project root.
-10. **set_rich_menu_default**
+9. **set_rich_menu_default**
     - Set a rich menu as the default rich menu.
     - **Inputs:**
       - `richMenuId` (string): The ID of the rich menu to set as default.
-11. **cancel_rich_menu_default**
+10. **cancel_rich_menu_default**
     - Cancel the default rich menu.
     - **Inputs:**
       - None

--- a/src/index.ts
+++ b/src/index.ts
@@ -277,10 +277,14 @@ server.tool(
   "Update a rich menu associated with your LINE Official Account.",
   {
     richMenuId: z.string().describe("The ID of the rich menu to update."),
+    projectPath: z.string().describe("The path of the project."),
     imagePath: z.string().describe("The path of the image to update."),
   },
-  async ({ richMenuId, imagePath }) => {
+  async ({ richMenuId, imagePath, projectPath }) => {
     try {
+      if (imagePath.startsWith("@")) {
+        imagePath = imagePath.replace("@", `${projectPath}/`);
+      }
       const imageBuffer = fs.readFileSync(imagePath);
       const imageType = "image/png";
       const imageBlob = new Blob([imageBuffer], { type: imageType });

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,6 +255,24 @@ server.tool(
 );
 
 server.tool(
+  "delete_rich_menu",
+  "Delete a rich menu from your LINE Official Account.",
+  {
+    richMenuId: z.string().describe("The ID of the rich menu to delete."),
+  },
+  async ({ richMenuId }) => {
+    try {
+      const response = await messagingApiClient.deleteRichMenu(richMenuId);
+      return createSuccessResponse(response);
+    } catch (error) {
+      return createErrorResponse(
+        `Failed to delete rich menu: ${error.message}`,
+      );
+    }
+  },
+);
+
+server.tool(
   "set_rich_menu_image",
   "Update a rich menu associated with your LINE Official Account.",
   {
@@ -290,6 +308,16 @@ server.tool(
   },
   async ({ richMenuId }) => {
     const response = await messagingApiClient.setDefaultRichMenu(richMenuId);
+    return createSuccessResponse(response);
+  },
+);
+
+server.tool(
+  "cancel_rich_menu_default",
+  "Cancel the default rich menu.",
+  {},
+  async () => {
+    const response = await messagingApiClient.cancelDefaultRichMenu();
     return createSuccessResponse(response);
   },
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import * as line from "@line/bot-sdk";
 import { z } from "zod";
-import pkg from "../package.json" with { type: "json" };
-import fs from "fs";
 import { LINE_BOT_MCP_SERVER_VERSION, USER_AGENT } from "./version.js";
 
 const NO_USER_ID_ERROR =
@@ -39,13 +37,6 @@ const messagingApiClient = new line.messagingApi.MessagingApiClient({
   channelAccessToken: channelAccessToken,
   defaultHeaders: {
     "User-Agent": USER_AGENT,
-  },
-});
-
-const lineBlobClient = new line.messagingApi.MessagingApiBlobClient({
-  channelAccessToken: channelAccessToken,
-  defaultHeaders: {
-    "User-Agent": `${pkg.name}/${pkg.version}`,
   },
 });
 
@@ -267,36 +258,6 @@ server.tool(
     } catch (error) {
       return createErrorResponse(
         `Failed to delete rich menu: ${error.message}`,
-      );
-    }
-  },
-);
-
-server.tool(
-  "set_rich_menu_image",
-  "Update a rich menu associated with your LINE Official Account.",
-  {
-    richMenuId: z.string().describe("The ID of the rich menu to update."),
-    projectPath: z.string().describe("The path of the project."),
-    imagePath: z.string().describe("The path of the image to update."),
-  },
-  async ({ richMenuId, imagePath, projectPath }) => {
-    try {
-      if (imagePath.startsWith("@")) {
-        imagePath = imagePath.replace("@", `${projectPath}/`);
-      }
-      const imageBuffer = fs.readFileSync(imagePath);
-      const imageType = "image/png";
-      const imageBlob = new Blob([imageBuffer], { type: imageType });
-
-      const response = await lineBlobClient.setRichMenuImage(
-        richMenuId,
-        imageBlob,
-      );
-      return createSuccessResponse(response);
-    } catch (error) {
-      return createErrorResponse(
-        `Failed to update rich menu: ${error.message}`,
       );
     }
   },


### PR DESCRIPTION
Hello! This is 4geru.

MCP is a helpful tool for development.
I'm planning to add some rich menu APIs on MCP.

This is a 1st PR for rich menu.

## added in this PR
- setDefaultRichMenu
- cancelDefaultRichMenu
- deleteRichMenu
- getRichMenuList

## planning in other PR
Related to development APIs
- createRichMenu
- setRichMenuImage
- createRichMenuAlias
- deleteRichMenuAlias
- getRichMenuAlias
- getRichMenuAliasList
- updateRichMenuAlias

## not planning in other PR
Not related to development APIs
- getDefaultRichMenuId
- getRichMenu
- getRichMenuIdOfUser
- linkRichMenuIdToUser
- linkRichMenuIdToUsers
- richMenuBatch
- unlinkRichMenuIdFromUser
- unlinkRichMenuIdFromUsers
- getRichMenuBatchProgress
- validateRichMenuBatchRequest
- validateRichMenuObject