### PR TITLE
Don't use PAT on publish by using trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,6 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           node .github/scripts/update-version.mjs $VERSION
       - run: npm run release
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Issue on Failure
         if: failure()

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format:check": "npm run prettier -- -l",
     "clean": "rm -rf dist/*",
     "prebuild": "npm run format:check && npm run clean",
-    "release": "npm run build && npm publish --provenance --access public"
+    "release": "npm run build && npm publish --provenance --access public --tag alpha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove PAT from publish workfrow to use https://docs.npmjs.com/trusted-publishers.

After confirming the operation by master merge, delete PAT from secrets and revoke.