### PR TITLE
Reminder for npm audit fix

### DIFF
--- a/.github/scripts/npm-audit.sh
+++ b/.github/scripts/npm-audit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IFS=$'\n'
+locks=($(find . -path '*/node_modules' -prune -o -name package-lock.json -print))
+unset IFS
+
+declare -a failed=()
+
+for lock in "${locks[@]}"; do
+  dir=$(dirname "$lock")
+  printf '\n\n\033[1;34m==> %s\033[0m\n' "$dir"
+
+  pushd "$dir" >/dev/null
+  if ! npm audit --audit-level moderate; then
+    failed+=("$dir")
+  fi
+  popd >/dev/null
+done
+
+if ((${#failed[@]})); then
+  echo -e "\n\033[0;31mnpm audit reported vulnerabilities in:\033[0m"
+  printf '  - %s\n' "${failed[@]}"
+  exit 1
+else
+  echo "npm audit passed: no vulnerabilities detected"
+  exit 0
+fi

--- a/.github/scripts/npm-audit.sh
+++ b/.github/scripts/npm-audit.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-IFS=$'\n'
-locks=($(find . -path '*/node_modules' -prune -o -name package-lock.json -print))
-unset IFS
+dirs=()
+while IFS= read -r path; do
+  dirs+=("$(dirname "$path")")
+done < <(
+  find . \( -path '*/node_modules' -o -path '*/dist' \) -prune -o \
+       \( -name package.json -o -name package-lock.json \) -print
+)
+
+IFS=$'\n' dirs=($(printf '%s\n' "${dirs[@]}" | sort -u)); unset IFS
 
 declare -a failed=()
 
-for lock in "${locks[@]}"; do
-  dir=$(dirname "$lock")
+for dir in "${dirs[@]}"; do
   printf '\n\n\033[1;34m==> %s\033[0m\n' "$dir"
 
   pushd "$dir" >/dev/null

--- a/.github/scripts/npm-audit.sh
+++ b/.github/scripts/npm-audit.sh
@@ -26,6 +26,8 @@ done
 if ((${#failed[@]})); then
   echo -e "\n\033[0;31mnpm audit reported vulnerabilities in:\033[0m"
   printf '  - %s\n' "${failed[@]}"
+  echo "You can run 'npm audit fix' in these directories to resolve the issues."
+  echo "If running 'npm audit fix' does not resolve the issues, you may need to manually update dependencies."
   exit 1
 else
   echo "npm audit passed: no vulnerabilities detected"

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 22 * * *'
   workflow_dispatch:
+  push:
+    branches:
+      - 'master'
 
 jobs:
   run-npm-audit:

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,0 +1,64 @@
+name: "Reminder for 'run npm audit'"
+
+on:
+  schedule:
+    - cron: '0 22 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-npm-audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    if: github.repository == 'line/line-bot-mcp-server'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '24'
+
+      - name: Run npm audit and check diff
+        id: audit
+        run: ./scripts/npm-audit.sh
+        continue-on-error: true
+
+      - name: Create or update reminder issue
+        if: steps.audit.outcome == 'failure'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          TZ: 'Asia/Tokyo'
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const title = 'Reminder: run npm audit';
+            const securityURL = `https://github.com/${owner}/${repo}/security`;
+            const baseBody = [
+              'Fix all vulnerabilities. You can check with `.github/scripts/npm-audit.sh` locally, then send a PR with the fixes.',
+              `After fixing, make sure the vulnerabilities count in **${securityURL}** is **0**.`
+            ].join('\n\n');
+
+            const { data: result } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue is:open in:title "${title}"`
+            });
+
+            const today = new Date();
+
+            if (result.total_count === 0) {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body: `${baseBody}\n\n0 days have passed.`
+              });
+            } else {
+              const issue = result.items[0];
+              const created = new Date(issue.created_at);
+              const diffDays = Math.floor((today - created) / 86_400_000);
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: `${baseBody}\n\n${diffDays} days have passed.`
+              });
+            }


### PR DESCRIPTION
Most npm package alerts can be fixed automatically with `npm audit fix --force` (it is not perfect, so some manual work is still required).
Because we cannot use a GitHub App token, a reminder should be enough. Automatically creating PRs would be pointless, because the CI jobs will not run, and it may be old(=merging may not resolve all issues)

For now, let's create a reminder as an issue. We review issues regularly, so this should be sufficient.

same as https://github.com/line/line-bot-sdk-nodejs/pull/1357