### PR TITLE
docs: add local development with Inspector guide to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -149,3 +149,35 @@ Claude DesktopやClaudeなどのAI Agentに次の設定を追加してくださ�
   }
 }
 ```
+
+## Inspector を使用したローカル開発
+
+MCP Inspector を使用して、サーバーをローカルでテストおよびデバッグできます。
+
+### 前提条件
+
+1. リポジトリをクローンする：
+```bash
+git clone git@github.com:line/line-bot-mcp-server.git
+cd line-bot-mcp-server
+```
+
+2. 依存関係をインストールする：
+```bash
+npm install
+```
+
+3. プロジェクトをビルドする：
+```bash
+npm run build
+```
+
+### Inspector の実行
+
+プロジェクトをビルドした後、MCP Inspector を起動できます：
+
+```bash
+npx @modelcontextprotocol/inspector node dist/index.js
+```
+
+これにより、MCP Inspector インターフェースが起動し、LINE Bot MCP Server のツールを操作して機能をテストできます。

--- a/README.md
+++ b/README.md
@@ -156,6 +156,38 @@ You can confirm this by following [this instructions](https://developers.line.bi
 }
 ```
 
+## Local Development with Inspector
+
+You can use the MCP Inspector to test and debug the server locally.
+
+### Prerequisites
+
+1. Clone the repository:
+```bash
+git clone git@github.com:line/line-bot-mcp-server.git
+cd line-bot-mcp-server
+```
+
+2. Install dependencies:
+```bash
+npm install
+```
+
+3. Build the project:
+```bash
+npm run build
+```
+
+### Run the Inspector
+
+After building the project, you can start the MCP Inspector:
+
+```bash
+npx @modelcontextprotocol/inspector node dist/index.js
+```
+
+This will start the MCP Inspector interface where you can interact with the LINE Bot MCP Server tools and test their functionality.
+
 ## Versioning
 
 This project respects semantic versioning


### PR DESCRIPTION
Added instructions for local development using MCP Inspector in both README files (English and Japanese).