### PR TITLE
Revert "chore(deps): update actions/setup-node digest to d7a1131"

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'line/line-bot-mcp-server'
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
-      - uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6
+      - uses: actions/setup-node@5e2628c959b9ade56971c0afcebbe5332d44b398
         with:
           node-version: '24'
 


### PR DESCRIPTION
Reverts line/line-bot-mcp-server#235

npm audit reminder failed due to this change. Let's revert this for now and investigate the root cause.

https://github.com/line/line-bot-mcp-server/actions/runs/17388450984/job/49358524334

```
5s
Run actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6
Attempting to download 24...
Acquiring 24.7.0 - x64 from https://github.com/actions/node-versions/releases/download/24.7.0-17283839804/node-24.7.0-linux-x64.tar.gz
Extracting ...
/usr/bin/tar xz --strip 1 --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/9d717e31-d874-4afd-a2e5-254743b7d5a9 -f /home/runner/work/_temp/d27465d5-d75a-4db4-9315-14430b9f1457
Adding to the cache ...
Environment details
Error: Unable to locate executable file: pnpm. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```