### PR TITLE
Add environment variable examples to MCP Inspector command

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -178,6 +178,8 @@ npm run build
 
 ```bash
 npx @modelcontextprotocol/inspector node dist/index.js
+  -e CHANNEL_ACCESS_TOKEN="YOUR_CHANNEL_ACCESS_TOKEN"
+  -e DESTINATION_USER_ID="YOUR_DESTINATION_USER_ID"
 ```
 
 これにより、MCP Inspector インターフェースが起動し、LINE Bot MCP Server のツールを操作して機能をテストできます。

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ After building the project, you can start the MCP Inspector:
 
 ```bash
 npx @modelcontextprotocol/inspector node dist/index.js
+  -e CHANNEL_ACCESS_TOKEN="YOUR_CHANNEL_ACCESS_TOKEN"
+  -e DESTINATION_USER_ID="YOUR_DESTINATION_USER_ID"
 ```
 
 This will start the MCP Inspector interface where you can interact with the LINE Bot MCP Server tools and test their functionality.


### PR DESCRIPTION
## Summary
- Add environment variable examples to the MCP Inspector command in both
English and Japanese README files
- Show how to properly pass `CHANNEL_ACCESS_TOKEN` and
`DESTINATION_USER_ID` when using the inspector

## Changes
- Updated `README.md` to include `-e` flags for required environment
variables
- Updated `README.ja.md` with the same environment variable documentation
in Japanese
