### PR TITLE
Set npm version as 11.6.0 in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,5 +13,9 @@
   ],
   ignoreDeps: [
     "zod"
-  ]
+  ],
+  // To prevent libraries in optionalDependencies from being removed from the lock file
+  constraints: {
+    npm: "11.6.0"
+  }
 }


### PR DESCRIPTION
We’re seeing an issue where Renovate removes libraries that are listed under optionalDependencies of line-bot-sdk-nodejs from the lockfile. Specifically, axios is being dropped from the lock file, which causes CI to fail. We found that pinning npm to 11.6.0 or below resolves the problem, so we’ll update our Renovate configuration to use npm 11.6.0.

However, we haven’t identified the root cause yet, as we can’t reproduce the issue locally even with npm 11.6.1 or later.