### PR TITLE
Use McpServer#registerTool instead of deprecated McpServer#tool

### DIFF
--- a/src/tools/broadcastFlexMessage.ts
+++ b/src/tools/broadcastFlexMessage.ts
@@ -16,17 +16,20 @@ export default class BroadcastFlexMessage extends AbstractTool {
   }
 
   register(server: McpServer) {
-    server.tool(
+    server.registerTool(
       "broadcast_flex_message",
-      "Broadcast a highly customizable flex message via LINE to all users who have added your LINE Official Account. " +
-        "Supports both bubble (single container) and carousel (multiple swipeable bubbles) layouts. Please be aware that " +
-        "this message will be sent to all users.",
-      {
-        message: flexMessageSchema,
-      },
       {
         title: "Broadcast Flex Message",
-        destructiveHint: true,
+        description:
+          "Broadcast a highly customizable flex message via LINE to all users who have added your LINE Official Account. " +
+          "Supports both bubble (single container) and carousel (multiple swipeable bubbles) layouts. Please be aware that " +
+          "this message will be sent to all users.",
+        inputSchema: {
+          message: flexMessageSchema,
+        },
+        annotations: {
+          destructiveHint: true,
+        },
       },
       async ({ message }) => {
         try {

--- a/src/tools/broadcastTextMessage.ts
+++ b/src/tools/broadcastTextMessage.ts
@@ -16,16 +16,19 @@ export default class BroadcastTextMessage extends AbstractTool {
   }
 
   register(server: McpServer) {
-    server.tool(
+    server.registerTool(
       "broadcast_text_message",
-      "Broadcast a simple text message via LINE to all users who have followed your LINE Official Account. Use this for sending " +
-        "plain text messages without formatting. Please be aware that this message will be sent to all users.",
-      {
-        message: textMessageSchema,
-      },
       {
         title: "Broadcast Text Message",
-        destructiveHint: true,
+        description:
+          "Broadcast a simple text message via LINE to all users who have followed your LINE Official Account. Use this for sending " +
+          "plain text messages without formatting. Please be aware that this message will be sent to all users.",
+        inputSchema: {
+          message: textMessageSchema,
+        },
+        annotations: {
+          destructiveHint: true,
+        },
       },
       async ({ message }) => {
         try {

--- a/src/tools/cancelRichMenuDefault.ts
+++ b/src/tools/cancelRichMenuDefault.ts
@@ -12,13 +12,14 @@ export default class CancelRichMenuDefault extends AbstractTool {
   }
 
   register(server: McpServer) {
-    server.tool(
+    server.registerTool(
       "cancel_rich_menu_default",
-      "Cancel the default rich menu.",
-      {},
       {
         title: "Cancel Rich Menu Default",
-        destructiveHint: true,
+        description: "Cancel the default rich menu.",
+        annotations: {
+          destructiveHint: true,
+        },
       },
       async () => {
         const response = await this.client.cancelDefaultRichMenu();

--- a/src/tools/createRichMenu.ts
+++ b/src/tools/createRichMenu.ts
@@ -32,24 +32,27 @@ export default class CreateRichMenu extends AbstractTool {
   }
 
   register(server: McpServer) {
-    server.tool(
+    server.registerTool(
       "create_rich_menu",
-      "Create a rich menu based on the given actions. Generate and upload a rich menu image based on the given action. This rich menu will be registered as the default.",
-      {
-        chatBarText: z
-          .string()
-          .describe(
-            "Text displayed in the chat bar and this is also used as name of the rich menu to create",
-          ),
-        actions: z
-          .array(actionSchema)
-          .min(1)
-          .max(6)
-          .describe("The actions of the rich menu."),
-      },
       {
         title: "Create Rich Menu",
-        destructiveHint: true,
+        description:
+          "Create a rich menu based on the given actions. Generate and upload a rich menu image based on the given action. This rich menu will be registered as the default.",
+        inputSchema: {
+          chatBarText: z
+            .string()
+            .describe(
+              "Text displayed in the chat bar and this is also used as name of the rich menu to create",
+            ),
+          actions: z
+            .array(actionSchema)
+            .min(1)
+            .max(6)
+            .describe("The actions of the rich menu."),
+        },
+        annotations: {
+          destructiveHint: true,
+        },
       },
       async ({ chatBarText, actions }) => {
         // Flow:

--- a/src/tools/deleteRichMenu.ts
+++ b/src/tools/deleteRichMenu.ts
@@ -20,17 +20,19 @@ export default class DeleteRichMenu extends AbstractTool {
       .string()
       .describe("The ID of the rich menu to delete.");
 
-    server.tool(
+    server.registerTool(
       "delete_rich_menu",
-      "Delete a rich menu from your LINE Official Account.",
-      {
-        richMenuId: richMenuIdSchema.describe(
-          "The ID of the rich menu to delete.",
-        ),
-      },
       {
         title: "Delete Rich Menu",
-        destructiveHint: true,
+        description: "Delete a rich menu from your LINE Official Account.",
+        inputSchema: {
+          richMenuId: richMenuIdSchema.describe(
+            "The ID of the rich menu to delete.",
+          ),
+        },
+        annotations: {
+          destructiveHint: true,
+        },
       },
       async ({ richMenuId }) => {
         try {

--- a/src/tools/getFollowerIds.ts
+++ b/src/tools/getFollowerIds.ts
@@ -16,22 +16,28 @@ export default class GetFollowerIds extends AbstractTool {
   }
 
   register(server: McpServer) {
-    server.tool(
+    server.registerTool(
       "get_follower_ids",
-      "Get a list of user IDs of users who have added the LINE Official Account as a friend. This allows you to obtain user IDs for sending messages without manually preparing them.",
       {
-        start: z
-          .string()
-          .optional()
-          .describe(
-            "Continuation token to get the next array of user IDs. Returned in the 'next' property of a previous response.",
-          ),
-        limit: z
-          .number()
-          .optional()
-          .describe(
-            "The maximum number of user IDs to retrieve in a single request.",
-          ),
+        description:
+          "Get a list of user IDs of users who have added the LINE Official Account as a friend. This allows you to obtain user IDs for sending messages without manually preparing them.",
+        inputSchema: {
+          start: z
+            .string()
+            .optional()
+            .describe(
+              "Continuation token to get the next array of user IDs. Returned in the 'next' property of a previous response.",
+            ),
+          limit: z
+            .number()
+            .optional()
+            .describe(
+              "The maximum number of user IDs to retrieve in a single request.",
+            ),
+        },
+        annotations: {
+          readOnlyHint: true,
+        },
       },
       async ({ start, limit }) => {
         try {

--- a/src/tools/getMessageQuota.ts
+++ b/src/tools/getMessageQuota.ts
@@ -12,13 +12,15 @@ export default class GetMessageQuota extends AbstractTool {
   }
 
   register(server: McpServer) {
-    server.tool(
+    server.registerTool(
       "get_message_quota",
-      "Get the message quota and consumption of the LINE Official Account. This shows the monthly message limit and current usage.",
-      {},
       {
         title: "Get Message Quota",
-        readOnlyHint: true,
+        description:
+          "Get the message quota and consumption of the LINE Official Account. This shows the monthly message limit and current usage.",
+        annotations: {
+          readOnlyHint: true,
+        },
       },
       async () => {
         const messageQuotaResponse = await this.client.getMessageQuota();

--- a/src/tools/getProfile.ts
+++ b/src/tools/getProfile.ts
@@ -26,15 +26,18 @@ export default class GetProfile extends AbstractTool {
         "The user ID to get a profile. Defaults to DESTINATION_USER_ID.",
       );
 
-    server.tool(
+    server.registerTool(
       "get_profile",
-      "Get detailed profile information of a LINE user including display name, profile picture URL, status message and language.",
-      {
-        userId: userIdSchema,
-      },
       {
         title: "Get Profile",
-        readOnlyHint: true,
+        description:
+          "Get detailed profile information of a LINE user including display name, profile picture URL, status message and language.",
+        inputSchema: {
+          userId: userIdSchema,
+        },
+        annotations: {
+          readOnlyHint: true,
+        },
       },
       async ({ userId }) => {
         if (!userId) {

--- a/src/tools/getRichMenuList.ts
+++ b/src/tools/getRichMenuList.ts
@@ -15,13 +15,15 @@ export default class GetRichMenuList extends AbstractTool {
   }
 
   register(server: McpServer) {
-    server.tool(
+    server.registerTool(
       "get_rich_menu_list",
-      "Get the list of rich menus associated with your LINE Official Account.",
-      {},
       {
         title: "Get Rich Menu List",
-        readOnlyHint: true,
+        description:
+          "Get the list of rich menus associated with your LINE Official Account.",
+        annotations: {
+          readOnlyHint: true,
+        },
       },
       async () => {
         try {

--- a/src/tools/pushFlexMessage.ts
+++ b/src/tools/pushFlexMessage.ts
@@ -27,17 +27,20 @@ export default class PushFlexMessage extends AbstractTool {
         "The user ID to receive a message. Defaults to DESTINATION_USER_ID.",
       );
 
-    server.tool(
+    server.registerTool(
       "push_flex_message",
-      "Push a highly customizable flex message to a user via LINE. Supports both bubble (single container) and carousel " +
-        "(multiple swipeable bubbles) layouts.",
-      {
-        userId: userIdSchema,
-        message: flexMessageSchema,
-      },
       {
         title: "Push Flex Message",
-        destructiveHint: true,
+        description:
+          "Push a highly customizable flex message to a user via LINE. Supports both bubble (single container) and carousel " +
+          "(multiple swipeable bubbles) layouts.",
+        inputSchema: {
+          userId: userIdSchema,
+          message: flexMessageSchema,
+        },
+        annotations: {
+          destructiveHint: true,
+        },
       },
       async ({ userId, message }) => {
         if (!userId) {

--- a/src/tools/pushTextMessage.ts
+++ b/src/tools/pushTextMessage.ts
@@ -27,16 +27,19 @@ export default class PushTextMessage extends AbstractTool {
         "The user ID to receive a message. Defaults to DESTINATION_USER_ID.",
       );
 
-    server.tool(
+    server.registerTool(
       "push_text_message",
-      "Push a simple text message to a user via LINE. Use this for sending plain text messages without formatting.",
-      {
-        userId: userIdSchema,
-        message: textMessageSchema,
-      },
       {
         title: "Push Text Message",
-        destructiveHint: true,
+        description:
+          "Push a simple text message to a user via LINE. Use this for sending plain text messages without formatting.",
+        inputSchema: {
+          userId: userIdSchema,
+          message: textMessageSchema,
+        },
+        annotations: {
+          destructiveHint: true,
+        },
       },
       async ({ userId, message }) => {
         if (!userId) {

--- a/src/tools/setRichMenuDefault.ts
+++ b/src/tools/setRichMenuDefault.ts
@@ -17,17 +17,19 @@ export default class SetRichMenuDefault extends AbstractTool {
       .string()
       .describe("The ID of the rich menu to set as default.");
 
-    server.tool(
+    server.registerTool(
       "set_rich_menu_default",
-      "Set a rich menu as the default rich menu.",
-      {
-        richMenuId: richMenuIdSchema.describe(
-          "The ID of the rich menu to set as default.",
-        ),
-      },
       {
         title: "Set Rich Menu Default",
-        destructiveHint: true,
+        description: "Set a rich menu as the default rich menu.",
+        inputSchema: {
+          richMenuId: richMenuIdSchema.describe(
+            "The ID of the rich menu to set as default.",
+          ),
+        },
+        annotations: {
+          destructiveHint: true,
+        },
       },
       async ({ richMenuId }) => {
         const response = await this.client.setDefaultRichMenu(richMenuId);


### PR DESCRIPTION
`McpServer#tool` is deprecated. It says we should use `McpServer#registerTool`. This change replaces all usage with the new way.