### PR TITLE
Remove empty options object from tool definitions

### DIFF
--- a/src/tools/cancelRichMenuDefault.ts
+++ b/src/tools/cancelRichMenuDefault.ts
@@ -15,7 +15,6 @@ export default class CancelRichMenuDefault extends AbstractTool {
     server.tool(
       "cancel_rich_menu_default",
       "Cancel the default rich menu.",
-      {},
       {
         title: "Cancel Rich Menu Default",
         destructiveHint: true,

--- a/src/tools/getMessageQuota.ts
+++ b/src/tools/getMessageQuota.ts
@@ -15,7 +15,6 @@ export default class GetMessageQuota extends AbstractTool {
     server.tool(
       "get_message_quota",
       "Get the message quota and consumption of the LINE Official Account. This shows the monthly message limit and current usage.",
-      {},
       {
         title: "Get Message Quota",
         readOnlyHint: true,

--- a/src/tools/getRichMenuList.ts
+++ b/src/tools/getRichMenuList.ts
@@ -18,7 +18,6 @@ export default class GetRichMenuList extends AbstractTool {
     server.tool(
       "get_rich_menu_list",
       "Get the list of rich menus associated with your LINE Official Account.",
-      {},
       {
         title: "Get Rich Menu List",
         readOnlyHint: true,


### PR DESCRIPTION
Resolve https://github.com/line/line-bot-mcp-server/issues/321

These tools were passing an empty object {} as the inputSchema, like server.tool(name, description, {}, annotations, cb). The MCP server converts this into a Zod object schema, which results in a validation error when arguments is null or undefined.