### PR TITLE
Update packages for npm audit (basic-ftp, hono)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@line/bot-sdk": "^11.0.0",
         "@marp-team/marp-cli": "^4.2.3",
         "@marp-team/marp-core": "^4.1.0",
-        "@modelcontextprotocol/sdk": "^1.8.0",
-        "puppeteer": "^24.27.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "puppeteer": "^24.40.0",
         "zod": "^3.25.76"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "@line/bot-sdk": "^11.0.0",
     "@marp-team/marp-cli": "^4.2.3",
     "@marp-team/marp-core": "^4.1.0",
-    "@modelcontextprotocol/sdk": "^1.8.0",
-    "puppeteer": "^24.27.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "puppeteer": "^24.40.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {


### PR DESCRIPTION
resolve #420 

It is within the min-release-age period, so the release will take place on or after 2026-04-26.

```
 # npm audit report

  basic-ftp  <=5.2.2
  Severity: high
  basic-ftp vulnerable to denial of service via unbounded memory consumption in Client.list() - https://github.com/advisories/GHSA-rp42-5vxx-qpwr
  fix available via `npm audit fix`
  node_modules/basic-ftp

  hono  <4.12.14
  Severity: moderate
  hono Improperly Handles JSX Attribute Names Allows HTML Injection in hono/jsx SSR - https://github.com/advisories/GHSA-458j-xx4x-4375
  fix available via `npm audit fix`
  node_modules/hono

  2 vulnerabilities (1 moderate, 1 high)
```