### PR TITLE
Use lock file maintenance by renovate to automate npm audit without PAT

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -20,8 +20,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
-          # Enable this when setup-node v5 is released
-          # package-manager-cache: false
+          package-manager-cache: false
 
       - name: Run npm audit and check diff
         id: audit

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -28,6 +28,34 @@ jobs:
         run: .github/scripts/npm-audit.sh
         continue-on-error: true
 
+      - name: Close reminder issue when audit passes
+        if: steps.audit.outcome == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const title = 'Reminder: run npm audit';
+
+            const { data: result } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue is:open in:title "${title}"`
+            });
+
+            for (const issue of result.items) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: 'Auto-closed because npm audit is now passing.'
+              });
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+            }
+
       - name: Create or update reminder issue
         if: steps.audit.outcome == 'failure'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,11 +11,11 @@
   labels: [
     "dependency upgrade"
   ],
-  ignoreDeps: [
-    "zod"
-  ],
-  // To prevent libraries in optionalDependencies from being removed from the lock file
-  constraints: {
-    npm: "11.15.0"
+  lockFileMaintenance: {
+    enabled: true,
+    automerge: true,
+    schedule: [
+      "after 1am and before 4am every day"
+    ]
   }
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,7 +13,6 @@
   ],
   lockFileMaintenance: {
     enabled: true,
-    automerge: true,
     schedule: [
       "after 1am and before 4am every day"
     ]


### PR DESCRIPTION
I recently discovered this. https://docs.renovatebot.com/configuration-options/#lockfilemaintenance

`npm audit` and GitHub Dependabot look at the lock file, but Renovate does not update dependencies that appear only in the lock file by default.

In most cases, except for dependencies that require manual resolution, simply recreating the lock file is enough to resolve audit issues.

Let’s use this approach. I have already verified it works in my fork repository.

Going forward, even when `npm audit` issues appear, we should be able to handle most of them simply by pressing the Renovate lock file maintenance button.
