### PR TITLE
Upgrade zod v3 to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@marp-team/marp-core": "^4.1.0",
         "@modelcontextprotocol/sdk": "^1.8.0",
         "puppeteer": "^24.27.0",
-        "zod": "^3.25.76"
+        "zod": "^4.0.0"
       },
       "bin": {
         "line-bot-mcp-server": "dist/index.js"
@@ -1669,6 +1669,15 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/cliui": {
@@ -5119,9 +5128,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@marp-team/marp-core": "^4.1.0",
     "@modelcontextprotocol/sdk": "^1.8.0",
     "puppeteer": "^24.27.0",
-    "zod": "^3.25.76"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.9.2",

--- a/src/common/schema/flexMessage.ts
+++ b/src/common/schema/flexMessage.ts
@@ -25,7 +25,6 @@ const imageSizeSchema = z.enum([
   "5xl",
   "full",
 ]);
-const spacerSizeSchema = z.enum(["xs", "sm", "md", "lg", "xl", "xxl"]);
 const marginSchema = z.enum(["none", "xs", "sm", "md", "lg", "xl", "xxl"]);
 const spacingSchema = z.enum(["none", "xs", "sm", "md", "lg", "xl", "xxl"]);
 const positionSchema = z.enum(["relative", "absolute"]);
@@ -116,7 +115,7 @@ const flexActionSchema = z.discriminatedUnion("type", [
       ),
     altUri: z
       .object({
-        desktop: z.string().url(),
+        desktop: z.url(),
       })
       .optional(),
   }),
@@ -192,7 +191,6 @@ const flexComponentSchema: z.ZodType<any> = z.lazy(() =>
     z.object({
       type: z.literal("icon"),
       url: z
-        .string()
         .url()
         .min(1)
         .max(2000)
@@ -211,7 +209,6 @@ const flexComponentSchema: z.ZodType<any> = z.lazy(() =>
     z.object({
       type: z.literal("image"),
       url: z
-        .string()
         .url()
         .min(1)
         .max(2000)
@@ -237,13 +234,11 @@ const flexComponentSchema: z.ZodType<any> = z.lazy(() =>
     z.object({
       type: z.literal("video"),
       url: z
-        .string()
         .url()
         .min(1)
         .max(2000)
         .refine(url => url.startsWith("https://"), "Must use HTTPS protocol"),
       previewUrl: z
-        .string()
         .url()
         .min(1)
         .max(2000)

--- a/src/common/schema/flexMessage.ts
+++ b/src/common/schema/flexMessage.ts
@@ -1,23 +1,30 @@
 import { z } from "zod";
 
-const sizeSchema = z
-  .enum(["xxs", "xs", "sm", "md", "lg", "xl", "xxl", "3xl", "4xl", "5xl"])
-  .default("md");
-const imageSizeSchema = z
-  .enum([
-    "xxs",
-    "xs",
-    "sm",
-    "md",
-    "lg",
-    "xl",
-    "xxl",
-    "3xl",
-    "4xl",
-    "5xl",
-    "full",
-  ])
-  .default("md");
+const sizeSchema = z.enum([
+  "xxs",
+  "xs",
+  "sm",
+  "md",
+  "lg",
+  "xl",
+  "xxl",
+  "3xl",
+  "4xl",
+  "5xl",
+]);
+const imageSizeSchema = z.enum([
+  "xxs",
+  "xs",
+  "sm",
+  "md",
+  "lg",
+  "xl",
+  "xxl",
+  "3xl",
+  "4xl",
+  "5xl",
+  "full",
+]);
 const spacerSizeSchema = z.enum(["xs", "sm", "md", "lg", "xl", "xxl"]);
 const marginSchema = z.enum(["none", "xs", "sm", "md", "lg", "xl", "xxl"]);
 const spacingSchema = z.enum(["none", "xs", "sm", "md", "lg", "xl", "xxl"]);


### PR DESCRIPTION
Close https://github.com/line/line-bot-mcp-server/pull/471

It looks like with Zod v3, `default` was not actually applied in the way we currently use it.

Since `size` for flex icon and flex text is optional, a default value is not really necessary.
- https://developers.line.biz/ja/reference/messaging-api/#flex-message

We could update the tests instead, but as long as we follow the Messaging API specification, either behavior should be acceptable.

So this removed the default value when upgrading zod's version.