### PR TITLE
Use unified client of @line/bot-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
       },
       "devDependencies": {
         "@types/node": "^24.9.2",
-        "prettier": "3.8.3",
-        "publint": "0.3.21",
+        "prettier": "^3.8.3",
+        "publint": "^0.3.21",
         "typescript": "^6.0.2",
         "vitest": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@types/node": "^24.9.2",
-    "prettier": "3.8.3",
-    "publint": "0.3.21",
+    "prettier": "^3.8.3",
+    "publint": "^0.3.21",
     "typescript": "^6.0.2",
     "vitest": "^4.0.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,33 +42,26 @@ const channelAccessToken = process.env.CHANNEL_ACCESS_TOKEN || "";
 const destinationId = process.env.DESTINATION_USER_ID || "";
 const messagingApiBaseUrl = process.env.LINE_MESSAGING_API_BASE_URL;
 
-const messagingApiClient = new line.messagingApi.MessagingApiClient({
+const lineBotClient = line.LineBotClient.fromChannelAccessToken({
   channelAccessToken: channelAccessToken,
-  baseURL: messagingApiBaseUrl,
+  apiBaseURL: messagingApiBaseUrl,
   defaultHeaders: {
     "User-Agent": USER_AGENT,
   },
 });
 
-const lineBlobClient = new line.messagingApi.MessagingApiBlobClient({
-  channelAccessToken: channelAccessToken,
-  defaultHeaders: {
-    "User-Agent": USER_AGENT,
-  },
-});
-
-new PushTextMessage(messagingApiClient, destinationId).register(server);
-new PushFlexMessage(messagingApiClient, destinationId).register(server);
-new BroadcastTextMessage(messagingApiClient).register(server);
-new BroadcastFlexMessage(messagingApiClient).register(server);
-new GetProfile(messagingApiClient, destinationId).register(server);
-new GetMessageQuota(messagingApiClient).register(server);
-new GetRichMenuList(messagingApiClient).register(server);
-new DeleteRichMenu(messagingApiClient).register(server);
-new SetRichMenuDefault(messagingApiClient).register(server);
-new CancelRichMenuDefault(messagingApiClient).register(server);
-new CreateRichMenu(messagingApiClient, lineBlobClient).register(server);
-new GetFollowerIds(messagingApiClient).register(server);
+new PushTextMessage(lineBotClient, destinationId).register(server);
+new PushFlexMessage(lineBotClient, destinationId).register(server);
+new BroadcastTextMessage(lineBotClient).register(server);
+new BroadcastFlexMessage(lineBotClient).register(server);
+new GetProfile(lineBotClient, destinationId).register(server);
+new GetMessageQuota(lineBotClient).register(server);
+new GetRichMenuList(lineBotClient).register(server);
+new DeleteRichMenu(lineBotClient).register(server);
+new SetRichMenuDefault(lineBotClient).register(server);
+new CancelRichMenuDefault(lineBotClient).register(server);
+new CreateRichMenu(lineBotClient).register(server);
+new GetFollowerIds(lineBotClient).register(server);
 
 async function main() {
   if (!process.env.CHANNEL_ACCESS_TOKEN) {

--- a/src/tools/broadcastFlexMessage.ts
+++ b/src/tools/broadcastFlexMessage.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient, messagingApi } from "@line/bot-sdk";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -8,9 +8,9 @@ import { AbstractTool } from "./AbstractTool.js";
 import { flexMessageSchema } from "../common/schema/flexMessage.js";
 
 export default class BroadcastFlexMessage extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
+  private client: LineBotClient;
 
-  constructor(client: messagingApi.MessagingApiClient) {
+  constructor(client: LineBotClient) {
     super();
     this.client = client;
   }

--- a/src/tools/broadcastTextMessage.ts
+++ b/src/tools/broadcastTextMessage.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient, messagingApi } from "@line/bot-sdk";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -8,9 +8,9 @@ import { AbstractTool } from "./AbstractTool.js";
 import { textMessageSchema } from "../common/schema/textMessage.js";
 
 export default class BroadcastTextMessage extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
+  private client: LineBotClient;
 
-  constructor(client: messagingApi.MessagingApiClient) {
+  constructor(client: LineBotClient) {
     super();
     this.client = client;
   }

--- a/src/tools/cancelRichMenuDefault.ts
+++ b/src/tools/cancelRichMenuDefault.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient } from "@line/bot-sdk";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -7,9 +7,9 @@ import {
 import { AbstractTool } from "./AbstractTool.js";
 
 export default class CancelRichMenuDefault extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
+  private client: LineBotClient;
 
-  constructor(client: messagingApi.MessagingApiClient) {
+  constructor(client: LineBotClient) {
     super();
     this.client = client;
   }

--- a/src/tools/createRichMenu.ts
+++ b/src/tools/createRichMenu.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient, messagingApi } from "@line/bot-sdk";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -19,16 +19,11 @@ const RICHMENU_HEIGHT = 910;
 const RICHMENU_WIDTH = 1600;
 
 export default class CreateRichMenu extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
-  private lineBlobClient: messagingApi.MessagingApiBlobClient;
+  private client: LineBotClient;
 
-  constructor(
-    client: messagingApi.MessagingApiClient,
-    lineBlobClient: messagingApi.MessagingApiBlobClient,
-  ) {
+  constructor(client: LineBotClient) {
     super();
     this.client = client;
-    this.lineBlobClient = lineBlobClient;
   }
 
   register(server: McpServer) {
@@ -95,7 +90,7 @@ export default class CreateRichMenu extends AbstractTool {
           const imageBuffer = fs.readFileSync(richMenuImagePath);
           const imageType = "image/png";
           const imageBlob = new Blob([imageBuffer], { type: imageType });
-          setImageResponse = await this.lineBlobClient.setRichMenuImage(
+          setImageResponse = await this.client.setRichMenuImage(
             richMenuId,
             imageBlob,
           );

--- a/src/tools/deleteRichMenu.ts
+++ b/src/tools/deleteRichMenu.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient } from "@line/bot-sdk";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -8,9 +8,9 @@ import { AbstractTool } from "./AbstractTool.js";
 import { z } from "zod";
 
 export default class DeleteRichMenu extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
+  private client: LineBotClient;
 
-  constructor(client: messagingApi.MessagingApiClient) {
+  constructor(client: LineBotClient) {
     super();
     this.client = client;
   }

--- a/src/tools/getFollowerIds.ts
+++ b/src/tools/getFollowerIds.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient } from "@line/bot-sdk";
 import { z } from "zod";
 import {
   createErrorResponse,
@@ -8,9 +8,9 @@ import {
 import { AbstractTool } from "./AbstractTool.js";
 
 export default class GetFollowerIds extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
+  private client: LineBotClient;
 
-  constructor(client: messagingApi.MessagingApiClient) {
+  constructor(client: LineBotClient) {
     super();
     this.client = client;
   }

--- a/src/tools/getMessageQuota.ts
+++ b/src/tools/getMessageQuota.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient } from "@line/bot-sdk";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -7,9 +7,9 @@ import {
 import { AbstractTool } from "./AbstractTool.js";
 
 export default class GetMessageQuota extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
+  private client: LineBotClient;
 
-  constructor(client: messagingApi.MessagingApiClient) {
+  constructor(client: LineBotClient) {
     super();
     this.client = client;
   }

--- a/src/tools/getProfile.ts
+++ b/src/tools/getProfile.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient } from "@line/bot-sdk";
 import { z } from "zod";
 import {
   createErrorResponse,
@@ -9,10 +9,10 @@ import { AbstractTool } from "./AbstractTool.js";
 import { NO_USER_ID_ERROR } from "../common/schema/constants.js";
 
 export default class GetProfile extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
+  private client: LineBotClient;
   private destinationId: string;
 
-  constructor(client: messagingApi.MessagingApiClient, destinationId: string) {
+  constructor(client: LineBotClient, destinationId: string) {
     super();
     this.client = client;
     this.destinationId = destinationId;

--- a/src/tools/getRichMenuList.ts
+++ b/src/tools/getRichMenuList.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient } from "@line/bot-sdk";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -7,9 +7,9 @@ import {
 import { AbstractTool } from "./AbstractTool.js";
 
 export default class GetRichMenuList extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
+  private client: LineBotClient;
 
-  constructor(client: messagingApi.MessagingApiClient) {
+  constructor(client: LineBotClient) {
     super();
     this.client = client;
   }

--- a/src/tools/pushFlexMessage.ts
+++ b/src/tools/pushFlexMessage.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient, messagingApi } from "@line/bot-sdk";
 import { z } from "zod";
 import {
   createErrorResponse,
@@ -10,10 +10,10 @@ import { NO_USER_ID_ERROR } from "../common/schema/constants.js";
 import { flexMessageSchema } from "../common/schema/flexMessage.js";
 
 export default class PushFlexMessage extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
+  private client: LineBotClient;
   private destinationId: string;
 
-  constructor(client: messagingApi.MessagingApiClient, destinationId: string) {
+  constructor(client: LineBotClient, destinationId: string) {
     super();
     this.client = client;
     this.destinationId = destinationId;

--- a/src/tools/pushTextMessage.ts
+++ b/src/tools/pushTextMessage.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient, messagingApi } from "@line/bot-sdk";
 import { z } from "zod";
 import {
   createErrorResponse,
@@ -10,10 +10,10 @@ import { NO_USER_ID_ERROR } from "../common/schema/constants.js";
 import { textMessageSchema } from "../common/schema/textMessage.js";
 
 export default class PushTextMessage extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
+  private client: LineBotClient;
   private destinationId: string;
 
-  constructor(client: messagingApi.MessagingApiClient, destinationId: string) {
+  constructor(client: LineBotClient, destinationId: string) {
     super();
     this.client = client;
     this.destinationId = destinationId;

--- a/src/tools/setRichMenuDefault.ts
+++ b/src/tools/setRichMenuDefault.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { messagingApi } from "@line/bot-sdk";
+import { LineBotClient } from "@line/bot-sdk";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -8,9 +8,9 @@ import { AbstractTool } from "./AbstractTool.js";
 import { z } from "zod";
 
 export default class SetRichMenuDefault extends AbstractTool {
-  private client: messagingApi.MessagingApiClient;
+  private client: LineBotClient;
 
-  constructor(client: messagingApi.MessagingApiClient) {
+  constructor(client: LineBotClient) {
     super();
     this.client = client;
   }

--- a/test/common/schema/flexMessage.test.ts
+++ b/test/common/schema/flexMessage.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { flexMessageSchema } from "../../../src/common/schema/flexMessage.js";
+
+const toFlexMessage = (component: unknown) => ({
+  type: "flex" as const,
+  altText: "Test message",
+  contents: {
+    type: "bubble" as const,
+    body: {
+      type: "box" as const,
+      layout: "vertical" as const,
+      contents: [component],
+    },
+  },
+});
+
+describe("flexMessageSchema URL validation", () => {
+  it("accepts valid URL values for image and altUri.desktop", () => {
+    const imageResult = flexMessageSchema.safeParse(
+      toFlexMessage({
+        type: "image",
+        url: "https://example.com/image.png",
+      }),
+    );
+    expect(imageResult.success).toBe(true);
+
+    const altUriResult = flexMessageSchema.safeParse(
+      toFlexMessage({
+        type: "button",
+        action: {
+          type: "uri",
+          label: "Open",
+          uri: "https://example.com/page",
+          altUri: {
+            desktop: "https://example.com/desktop",
+          },
+        },
+      }),
+    );
+    expect(altUriResult.success).toBe(true);
+  });
+
+  it("rejects malformed URL in image.url", () => {
+    const result = flexMessageSchema.safeParse(
+      toFlexMessage({
+        type: "image",
+        url: "not-a-url",
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(issue => issue.path.includes("url")),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects non-https URL in icon.url", () => {
+    const result = flexMessageSchema.safeParse(
+      toFlexMessage({
+        type: "icon",
+        url: "http://example.com/icon.png",
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          issue =>
+            issue.path.includes("url") &&
+            issue.message.includes("Must use HTTPS protocol"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects malformed URL in uri action altUri.desktop", () => {
+    const result = flexMessageSchema.safeParse(
+      toFlexMessage({
+        type: "button",
+        action: {
+          type: "uri",
+          label: "Open",
+          uri: "https://example.com/page",
+          altUri: {
+            desktop: "invalid-desktop-url",
+          },
+        },
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(issue => issue.path.includes("desktop")),
+      ).toBe(true);
+    }
+  });
+});

--- a/test/helpers/mock-line-clients.ts
+++ b/test/helpers/mock-line-clients.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
-import type { messagingApi } from "@line/bot-sdk";
+import type { LineBotClient } from "@line/bot-sdk";
 
-export function createMockMessagingApiClient() {
+export function createMockLineBotClient() {
   return {
     pushMessage: vi.fn(),
     broadcast: vi.fn(),
@@ -14,11 +14,6 @@ export function createMockMessagingApiClient() {
     cancelDefaultRichMenu: vi.fn(),
     createRichMenu: vi.fn(),
     getFollowers: vi.fn(),
-  } as unknown as messagingApi.MessagingApiClient;
-}
-
-export function createMockBlobClient() {
-  return {
     setRichMenuImage: vi.fn(),
-  } as unknown as messagingApi.MessagingApiBlobClient;
+  } as unknown as LineBotClient;
 }

--- a/test/tools/broadcastFlexMessage.test.ts
+++ b/test/tools/broadcastFlexMessage.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMockMessagingApiClient } from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 import BroadcastFlexMessage from "../../src/tools/broadcastFlexMessage.js";
 
 const SAMPLE_FLEX_MESSAGE = {
@@ -35,10 +35,10 @@ const EXPECTED_FLEX_MESSAGE = {
 describe("broadcast_flex_message tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
     new BroadcastFlexMessage(mockLineClient).register(server);
 

--- a/test/tools/broadcastTextMessage.test.ts
+++ b/test/tools/broadcastTextMessage.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMockMessagingApiClient } from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 import BroadcastTextMessage from "../../src/tools/broadcastTextMessage.js";
 
 describe("broadcast_text_message tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
     new BroadcastTextMessage(mockLineClient).register(server);
 

--- a/test/tools/cancelRichMenuDefault.test.ts
+++ b/test/tools/cancelRichMenuDefault.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMockMessagingApiClient } from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 import CancelRichMenuDefault from "../../src/tools/cancelRichMenuDefault.js";
 
 describe("cancel_rich_menu_default tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
     new CancelRichMenuDefault(mockLineClient).register(server);
 

--- a/test/tools/createRichMenu.test.ts
+++ b/test/tools/createRichMenu.test.ts
@@ -2,10 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import {
-  createMockMessagingApiClient,
-  createMockBlobClient,
-} from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 
 // Mock external dependencies before importing the tool.
 // vi.mock factories are hoisted, so all values must be created inline.
@@ -57,14 +54,12 @@ import CreateRichMenu from "../../src/tools/createRichMenu.js";
 describe("create_rich_menu tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
-  let mockBlobClient: ReturnType<typeof createMockBlobClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
-    mockBlobClient = createMockBlobClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
-    new CreateRichMenu(mockLineClient, mockBlobClient).register(server);
+    new CreateRichMenu(mockLineClient).register(server);
 
     const [clientTransport, serverTransport] =
       InMemoryTransport.createLinkedPair();
@@ -87,7 +82,7 @@ describe("create_rich_menu tool", () => {
       vi.mocked(mockLineClient.createRichMenu).mockResolvedValue({
         richMenuId: "richmenu-new-123",
       } as never);
-      vi.mocked(mockBlobClient.setRichMenuImage).mockResolvedValue({} as never);
+      vi.mocked(mockLineClient.setRichMenuImage).mockResolvedValue({} as never);
       vi.mocked(mockLineClient.setDefaultRichMenu).mockResolvedValue(
         {} as never,
       );
@@ -111,7 +106,7 @@ describe("create_rich_menu tool", () => {
           size: { width: 1600, height: 910 },
         }),
       );
-      expect(mockBlobClient.setRichMenuImage).toHaveBeenCalledWith(
+      expect(mockLineClient.setRichMenuImage).toHaveBeenCalledWith(
         "richmenu-new-123",
         expect.any(Blob),
       );
@@ -220,7 +215,7 @@ describe("create_rich_menu tool", () => {
       vi.mocked(mockLineClient.createRichMenu).mockResolvedValue({
         richMenuId: "richmenu-new-123",
       } as never);
-      vi.mocked(mockBlobClient.setRichMenuImage).mockResolvedValue({} as never);
+      vi.mocked(mockLineClient.setRichMenuImage).mockResolvedValue({} as never);
       vi.mocked(mockLineClient.setDefaultRichMenu).mockResolvedValue(
         {} as never,
       );

--- a/test/tools/deleteRichMenu.test.ts
+++ b/test/tools/deleteRichMenu.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMockMessagingApiClient } from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 import DeleteRichMenu from "../../src/tools/deleteRichMenu.js";
 
 describe("delete_rich_menu tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
     new DeleteRichMenu(mockLineClient).register(server);
 

--- a/test/tools/getFollowerIds.test.ts
+++ b/test/tools/getFollowerIds.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMockMessagingApiClient } from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 import GetFollowerIds from "../../src/tools/getFollowerIds.js";
 
 describe("get_follower_ids tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
     new GetFollowerIds(mockLineClient).register(server);
 

--- a/test/tools/getMessageQuota.test.ts
+++ b/test/tools/getMessageQuota.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMockMessagingApiClient } from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 import GetMessageQuota from "../../src/tools/getMessageQuota.js";
 
 describe("get_message_quota tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
     new GetMessageQuota(mockLineClient).register(server);
 

--- a/test/tools/getProfile.test.ts
+++ b/test/tools/getProfile.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMockMessagingApiClient } from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 import GetProfile from "../../src/tools/getProfile.js";
 
 const DESTINATION_ID = "U_DEFAULT_USER";
@@ -10,10 +10,10 @@ const DESTINATION_ID = "U_DEFAULT_USER";
 describe("get_profile tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
     new GetProfile(mockLineClient, DESTINATION_ID).register(server);
 

--- a/test/tools/getRichMenuList.test.ts
+++ b/test/tools/getRichMenuList.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMockMessagingApiClient } from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 import GetRichMenuList from "../../src/tools/getRichMenuList.js";
 
 describe("get_rich_menu_list tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
     new GetRichMenuList(mockLineClient).register(server);
 

--- a/test/tools/pushFlexMessage.test.ts
+++ b/test/tools/pushFlexMessage.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMockMessagingApiClient } from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 import PushFlexMessage from "../../src/tools/pushFlexMessage.js";
 
 const DESTINATION_ID = "U_DEFAULT_USER";
@@ -37,10 +37,10 @@ const EXPECTED_FLEX_MESSAGE = {
 describe("push_flex_message tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
     new PushFlexMessage(mockLineClient, DESTINATION_ID).register(server);
 

--- a/test/tools/pushTextMessage.test.ts
+++ b/test/tools/pushTextMessage.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMockMessagingApiClient } from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 import PushTextMessage from "../../src/tools/pushTextMessage.js";
 
 const DESTINATION_ID = "U_DEFAULT_USER";
@@ -10,10 +10,10 @@ const DESTINATION_ID = "U_DEFAULT_USER";
 describe("push_text_message tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
     new PushTextMessage(mockLineClient, DESTINATION_ID).register(server);
 

--- a/test/tools/setRichMenuDefault.test.ts
+++ b/test/tools/setRichMenuDefault.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMockMessagingApiClient } from "../helpers/mock-line-clients.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
 import SetRichMenuDefault from "../../src/tools/setRichMenuDefault.js";
 
 describe("set_rich_menu_default tool", () => {
   let client: Client;
   let server: McpServer;
-  let mockLineClient: ReturnType<typeof createMockMessagingApiClient>;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
 
   beforeEach(async () => {
-    mockLineClient = createMockMessagingApiClient();
+    mockLineClient = createMockLineBotClient();
     server = new McpServer({ name: "test", version: "0.0.1" });
     new SetRichMenuDefault(mockLineClient).register(server);
 


### PR DESCRIPTION
As we wrote https://line.github.io/line-bot-sdk-nodejs/guide/migration.html, there is no longer any need to choose different clients based on API endpoints. (like, `messagingApi.MessagingApiClient` and `messagingApi.MessagingApiBlobClient`)

This change just refactors the code to use the unified client. There is no behavior change.