### PR TITLE
Add get_rich_menu and update_rich_menu_image tools

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -45,19 +45,23 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
    - LINE公式アカウントに登録されているリッチメニューの一覧を取得する。
    - **入力:**
      - なし
-8. **delete_rich_menu**
+8. **get_rich_menu**
+   - IDを指定してリッチメニューを取得する。サイズ、チャットバーのテキスト、タップ領域を含む。
+   - **入力:**
+     - `richMenuId` (string): 取得するリッチメニューのID。
+9. **delete_rich_menu**
    - LINE公式アカウントからリッチメニューを削除する。
    - **入力:**
      - `richMenuId` (string): 削除するリッチメニューのID。
-9. **set_rich_menu_default**
+10. **set_rich_menu_default**
     - リッチメニューをデフォルトとして設定する。
     - **入力:**
       - `richMenuId` (string): デフォルトとして設定するリッチメニューのID。
-10. **cancel_rich_menu_default**
+11. **cancel_rich_menu_default**
     - デフォルトのリッチメニューを解除する。
     - **入力:**
       - なし
-11. **create_rich_menu**
+12. **create_rich_menu**
     - 指定されたアクションに基づいてリッチメニューを作成。画像を生成してアップロード。デフォルトとして設定する。
     - **入力:**
       - `chatBarText` (string): チャットバー表示、リッチメニュー名にされるテキスト。
@@ -72,7 +76,14 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
         - `richmenuswitch`: 別のリッチメニューに切り替える
         - `clipboard`: テキストをクリップボードにコピーする
 
-12. **get_follower_ids**
+13. **update_rich_menu_image**
+    - 既存リッチメニューの画像を差し替える。LINEでは一度アップロードしたリッチメニュー画像の上書きができないため、clone-and-replace方式を採用する: 同一定義の新しいリッチメニューを作成し、新しい画像をアップロードし、旧メニューがデフォルトの場合はデフォルトを引き継ぎ、旧メニューを削除する。この結果、**新しい`richMenuId`が発行され**、旧`richMenuId`は無効になる。
+    - **入力:**
+      - `richMenuId` (string): 画像を更新するリッチメニューのID。
+      - `imagePath` (string): 新しい画像のローカルファイルパス。PNGまたはJPEG、幅800-2500px、高さ250px以上、アスペクト比1.45以上、最大1MB。寸法は既存のリッチメニューサイズ（例: 1600x910）と一致する必要がある。
+      - `deleteOldRichMenu` (boolean?): 差し替え後に旧リッチメニューを削除するかどうか。デフォルトはtrue。
+
+14. **get_follower_ids**
     - LINE公式アカウントを友だち追加しているユーザーのユーザーIDリストを取得する。これにより、DESTINATION_USER_IDを手動で準備せずにユーザーIDを取得できる。
     - **入力:**
       - `start` (string?): 次のユーザーID配列を取得するための継続トークン。前回のレスポンスの`next`プロパティから取得できる。

--- a/README.md
+++ b/README.md
@@ -47,19 +47,23 @@
    - Get the list of rich menus associated with your LINE Official Account.
    - **Inputs:**
      - None
-8. **delete_rich_menu**
+8. **get_rich_menu**
+   - Get a rich menu by ID, including its size, chat bar text, and tap areas.
+   - **Inputs:**
+     - `richMenuId` (string): The ID of the rich menu to get.
+9. **delete_rich_menu**
    - Delete a rich menu from your LINE Official Account.
    - **Inputs:**
      - `richMenuId` (string): The ID of the rich menu to delete.
-9. **set_rich_menu_default**
+10. **set_rich_menu_default**
     - Set a rich menu as the default rich menu.
     - **Inputs:**
       - `richMenuId` (string): The ID of the rich menu to set as default.
-10. **cancel_rich_menu_default**
+11. **cancel_rich_menu_default**
     - Cancel the default rich menu.
     - **Inputs:**
       - None
-11. **create_rich_menu**
+12. **create_rich_menu**
     - Create a rich menu based on the given actions. Generate and upload an image. Set as default.
     - **Inputs:**
       - `chatBarText` (string): Text displayed in chat bar, also used as rich menu name.
@@ -74,7 +78,14 @@
         - `richmenuswitch`: For switching to another rich menu
         - `clipboard`: For copying text to clipboard
 
-12. **get_follower_ids**
+13. **update_rich_menu_image**
+    - Replace the image of an existing rich menu. LINE does not allow overwriting an already uploaded rich menu image, so this tool uses a clone-and-replace strategy: it creates a new rich menu with the same definition, uploads the new image, takes over the default assignment if the old menu was the default, and deletes the old menu. As a result, a **new `richMenuId` is issued** and the old one is no longer valid.
+    - **Inputs:**
+      - `richMenuId` (string): The ID of the rich menu whose image to update.
+      - `imagePath` (string): Local file path to the new image. PNG or JPEG, width 800-2500px, height >= 250px, aspect ratio >= 1.45, max 1MB. Dimensions must match the existing rich menu size (e.g. 1600x910).
+      - `deleteOldRichMenu` (boolean?): Whether to delete the old rich menu after replacement. Defaults to true.
+
+14. **get_follower_ids**
     - Get a list of user IDs of users who have added the LINE Official Account as a friend. This allows you to obtain user IDs for sending messages without manually preparing them.
     - **Inputs:**
       - `start` (string?): Continuation token to get the next array of user IDs. Returned in the `next` property of a previous response.

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,11 @@ import BroadcastFlexMessage from "./tools/broadcastFlexMessage.js";
 import GetProfile from "./tools/getProfile.js";
 import GetMessageQuota from "./tools/getMessageQuota.js";
 import GetRichMenuList from "./tools/getRichMenuList.js";
+import GetRichMenu from "./tools/getRichMenu.js";
 import DeleteRichMenu from "./tools/deleteRichMenu.js";
 import SetRichMenuDefault from "./tools/setRichMenuDefault.js";
 import CreateRichMenu from "./tools/createRichMenu.js";
+import UpdateRichMenuImage from "./tools/updateRichMenuImage.js";
 import GetFollowerIds from "./tools/getFollowerIds.js";
 
 const server = new McpServer({
@@ -57,10 +59,12 @@ new BroadcastFlexMessage(lineBotClient).register(server);
 new GetProfile(lineBotClient, destinationId).register(server);
 new GetMessageQuota(lineBotClient).register(server);
 new GetRichMenuList(lineBotClient).register(server);
+new GetRichMenu(lineBotClient).register(server);
 new DeleteRichMenu(lineBotClient).register(server);
 new SetRichMenuDefault(lineBotClient).register(server);
 new CancelRichMenuDefault(lineBotClient).register(server);
 new CreateRichMenu(lineBotClient).register(server);
+new UpdateRichMenuImage(lineBotClient).register(server);
 new GetFollowerIds(lineBotClient).register(server);
 
 async function main() {

--- a/src/tools/getRichMenu.ts
+++ b/src/tools/getRichMenu.ts
@@ -1,0 +1,44 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { LineBotClient } from "@line/bot-sdk";
+import {
+  createErrorResponse,
+  createSuccessResponse,
+} from "../common/response.js";
+import { AbstractTool } from "./AbstractTool.js";
+import { z } from "zod";
+
+export default class GetRichMenu extends AbstractTool {
+  private client: LineBotClient;
+
+  constructor(client: LineBotClient) {
+    super();
+    this.client = client;
+  }
+
+  register(server: McpServer) {
+    server.registerTool(
+      "get_rich_menu",
+      {
+        title: "Get Rich Menu",
+        description:
+          "Get a rich menu by ID, including its size, chat bar text, and tap areas.",
+        inputSchema: {
+          richMenuId: z.string().describe("The ID of the rich menu to get."),
+        },
+        annotations: {
+          readOnlyHint: true,
+        },
+      },
+      async ({ richMenuId }) => {
+        try {
+          const response = await this.client.getRichMenu(richMenuId);
+          return createSuccessResponse(response);
+        } catch (error: unknown) {
+          return createErrorResponse(
+            `Failed to get rich menu: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+    );
+  }
+}

--- a/src/tools/updateRichMenuImage.ts
+++ b/src/tools/updateRichMenuImage.ts
@@ -1,0 +1,290 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { LineBotClient, messagingApi } from "@line/bot-sdk";
+import {
+  createErrorResponse,
+  createSuccessResponse,
+} from "../common/response.js";
+import { AbstractTool } from "./AbstractTool.js";
+import { z } from "zod";
+import fs from "fs";
+import path from "path";
+
+const MIN_WIDTH = 800;
+const MAX_WIDTH = 2500;
+const MIN_HEIGHT = 250;
+const MIN_ASPECT_RATIO = 1.45;
+const MAX_FILE_SIZE = 1_048_576; // 1MB
+
+export type ImageDimensions = { width: number; height: number };
+
+/**
+ * Parse the width/height of a PNG or JPEG file by reading its binary header only.
+ * No image decoding is performed.
+ */
+export function readImageDimensions(
+  buffer: Buffer,
+  ext: string,
+): ImageDimensions {
+  if (ext === ".png") {
+    // PNG signature (8 bytes) + IHDR chunk. width at offset 16, height at offset 20.
+    if (buffer.length < 24) {
+      throw new Error("Invalid PNG file: header is too short.");
+    }
+    const width = buffer.readUInt32BE(16);
+    const height = buffer.readUInt32BE(20);
+    return { width, height };
+  }
+
+  // JPEG: scan markers until a Start Of Frame (SOF) marker is found.
+  // SOF markers are 0xC0-0xCF, excluding DHT (0xC4), DAC (0xCC) and RSTn (0xD0-0xD7).
+  let offset = 2; // skip the 0xFFD8 SOI marker
+  while (offset < buffer.length) {
+    if (buffer[offset] !== 0xff) {
+      offset++;
+      continue;
+    }
+    const marker = buffer[offset + 1];
+    if (
+      marker >= 0xc0 &&
+      marker <= 0xcf &&
+      marker !== 0xc4 &&
+      marker !== 0xc8 &&
+      marker !== 0xcc
+    ) {
+      // SOF marker: height at marker+5 (u16 BE), width at marker+7 (u16 BE).
+      const height = buffer.readUInt16BE(offset + 5);
+      const width = buffer.readUInt16BE(offset + 7);
+      return { width, height };
+    }
+    // Skip this segment using its length field.
+    const segmentLength = buffer.readUInt16BE(offset + 2);
+    offset += 2 + segmentLength;
+  }
+  throw new Error(
+    "Invalid JPEG file: no Start Of Frame marker found; cannot read image dimensions.",
+  );
+}
+
+/**
+ * Validate the new image against LINE rich menu image constraints and against
+ * the existing rich menu size. Throws an actionable Error on any violation.
+ */
+export function validateRichMenuImage(
+  imagePath: string,
+  richMenuSize: messagingApi.RichMenuSize,
+): { dimensions: ImageDimensions; contentType: string } {
+  if (!fs.existsSync(imagePath)) {
+    throw new Error(
+      `Image file not found at "${imagePath}". Provide a valid local file path to an existing PNG or JPEG image.`,
+    );
+  }
+
+  const ext = path.extname(imagePath).toLowerCase();
+  if (ext !== ".png" && ext !== ".jpg" && ext !== ".jpeg") {
+    throw new Error(
+      `Unsupported image extension "${ext || "(none)"}". Provide a PNG or JPEG file with a .png, .jpg or .jpeg extension.`,
+    );
+  }
+  const contentType = ext === ".png" ? "image/png" : "image/jpeg";
+
+  const stats = fs.statSync(imagePath);
+  if (stats.size > MAX_FILE_SIZE) {
+    throw new Error(
+      `Image file is ${stats.size} bytes but the maximum allowed is ${MAX_FILE_SIZE} bytes (1MB). Compress or re-export the image to be at most 1MB.`,
+    );
+  }
+
+  const buffer = fs.readFileSync(imagePath);
+  const dimensions = readImageDimensions(buffer, ext);
+  const { width, height } = dimensions;
+
+  if (width < MIN_WIDTH || width > MAX_WIDTH) {
+    throw new Error(
+      `Image width is ${width}px but must be between ${MIN_WIDTH} and ${MAX_WIDTH}px. Regenerate the image with a width in that range (ideally ${richMenuSize.width}px to match the rich menu).`,
+    );
+  }
+  if (height < MIN_HEIGHT) {
+    throw new Error(
+      `Image height is ${height}px but must be at least ${MIN_HEIGHT}px. Regenerate the image taller (ideally ${richMenuSize.height}px to match the rich menu).`,
+    );
+  }
+  const aspectRatio = width / height;
+  if (aspectRatio < MIN_ASPECT_RATIO) {
+    throw new Error(
+      `Image aspect ratio (width/height) is ${aspectRatio.toFixed(3)} but must be at least ${MIN_ASPECT_RATIO}. Regenerate the image wider relative to its height (e.g. ${richMenuSize.width}x${richMenuSize.height}).`,
+    );
+  }
+
+  if (width !== richMenuSize.width || height !== richMenuSize.height) {
+    throw new Error(
+      `Image is ${width}x${height} but the rich menu size is ${richMenuSize.width}x${richMenuSize.height}. Regenerate the image at exactly ${richMenuSize.width}x${richMenuSize.height} px.`,
+    );
+  }
+
+  return { dimensions, contentType };
+}
+
+export default class UpdateRichMenuImage extends AbstractTool {
+  private client: LineBotClient;
+
+  constructor(client: LineBotClient) {
+    super();
+    this.client = client;
+  }
+
+  register(server: McpServer) {
+    server.registerTool(
+      "update_rich_menu_image",
+      {
+        title: "Update Rich Menu Image",
+        description:
+          "Replace the image of an existing rich menu. LINE does not allow overwriting an already uploaded rich menu image, so this tool uses a clone-and-replace strategy: it creates a new rich menu with the same definition as the old one, uploads the new image, takes over the default assignment if the old menu was the default, and deletes the old menu. As a result, a NEW richMenuId is issued and returned; the old richMenuId will no longer be valid. Image constraints: PNG or JPEG, width 800-2500px, height >= 250px, aspect ratio (width/height) >= 1.45, max 1MB. The image dimensions must match the size of the existing rich menu.",
+        inputSchema: {
+          richMenuId: z
+            .string()
+            .describe("The ID of the rich menu whose image to update."),
+          imagePath: z
+            .string()
+            .describe(
+              "Local file path to the new image. PNG or JPEG, width 800-2500px, height >= 250px, aspect ratio >= 1.45, max 1MB. Dimensions must match the existing rich menu size (e.g. 1600x910).",
+            ),
+          deleteOldRichMenu: z
+            .boolean()
+            .default(true)
+            .describe(
+              "Whether to delete the old rich menu after replacement. Defaults to true.",
+            ),
+        },
+        annotations: {
+          destructiveHint: true,
+        },
+      },
+      async ({ richMenuId, imagePath, deleteOldRichMenu }) => {
+        try {
+          // 1. Fetch the old rich menu definition.
+          let oldRichMenu: messagingApi.RichMenuResponse;
+          try {
+            oldRichMenu = await this.client.getRichMenu(richMenuId);
+          } catch (error: unknown) {
+            return createErrorResponse(
+              `Failed to get the rich menu "${richMenuId}": ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+
+          // 2. Validate the new image (before any API calls that mutate state).
+          let contentType: string;
+          try {
+            ({ contentType } = validateRichMenuImage(
+              imagePath,
+              oldRichMenu.size,
+            ));
+          } catch (error: unknown) {
+            return createErrorResponse(
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+
+          // 3. Create a new rich menu with the same definition as the old one.
+          const richMenuRequest: messagingApi.RichMenuRequest = {
+            size: oldRichMenu.size,
+            selected: oldRichMenu.selected,
+            name: oldRichMenu.name,
+            chatBarText: oldRichMenu.chatBarText,
+            areas: oldRichMenu.areas,
+          };
+          const createResponse =
+            await this.client.createRichMenu(richMenuRequest);
+          const newRichMenuId = createResponse.richMenuId;
+
+          // 4. Upload the new image. Roll back the new menu on failure.
+          try {
+            const imageBuffer = fs.readFileSync(imagePath);
+            const imageBlob = new Blob([imageBuffer], { type: contentType });
+            await this.client.setRichMenuImage(newRichMenuId, imageBlob);
+          } catch (uploadError: unknown) {
+            let rollbackError: unknown = null;
+            try {
+              await this.client.deleteRichMenu(newRichMenuId);
+            } catch (error: unknown) {
+              rollbackError = error;
+            }
+            return createErrorResponse(
+              JSON.stringify({
+                error: `Failed to upload the new rich menu image: ${uploadError instanceof Error ? uploadError.message : String(uploadError)}`,
+                newRichMenuId,
+                rolledBack: rollbackError === null,
+                rollbackError:
+                  rollbackError === null
+                    ? undefined
+                    : `Failed to delete the newly created rich menu "${newRichMenuId}" during rollback: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+              }),
+            );
+          }
+
+          // 5. Determine whether the old menu was the default and take it over.
+          let oldWasDefault = false;
+          try {
+            const defaultResponse = await this.client.getDefaultRichMenuId();
+            oldWasDefault = defaultResponse.richMenuId === richMenuId;
+          } catch {
+            // No default rich menu is set (LINE returns 404). Treat as "no default".
+            oldWasDefault = false;
+          }
+
+          let defaultSwitched = false;
+          let defaultSwitchError: string | undefined;
+          if (oldWasDefault) {
+            try {
+              await this.client.setDefaultRichMenu(newRichMenuId);
+              defaultSwitched = true;
+            } catch (error: unknown) {
+              defaultSwitchError = `Failed to switch the default rich menu to "${newRichMenuId}": ${error instanceof Error ? error.message : String(error)}`;
+            }
+          }
+
+          // 6. Delete the old rich menu (unless the default switch failed).
+          let oldRichMenuDeleted = false;
+          let deleteError: string | undefined;
+          if (oldWasDefault && !defaultSwitched) {
+            // Do not delete the old menu; it is still the active default.
+            return createErrorResponse(
+              JSON.stringify({
+                error: defaultSwitchError,
+                oldRichMenuId: richMenuId,
+                newRichMenuId,
+                defaultSwitched,
+                oldRichMenuDeleted,
+                message:
+                  "The new rich menu and image were created, but switching the default failed. The old rich menu was kept as the active default. Retry setting the default to the new rich menu manually, then delete the old one.",
+              }),
+            );
+          }
+
+          if (deleteOldRichMenu) {
+            try {
+              await this.client.deleteRichMenu(richMenuId);
+              oldRichMenuDeleted = true;
+            } catch (error: unknown) {
+              deleteError = `Failed to delete the old rich menu "${richMenuId}": ${error instanceof Error ? error.message : String(error)}`;
+            }
+          }
+
+          return createSuccessResponse({
+            message:
+              "Rich menu image updated via clone-and-replace. A new richMenuId was issued; the old richMenuId is no longer valid." +
+              (deleteError ? ` Warning: ${deleteError}` : ""),
+            oldRichMenuId: richMenuId,
+            newRichMenuId,
+            defaultSwitched,
+            oldRichMenuDeleted,
+            ...(deleteError ? { deleteError } : {}),
+          });
+        } catch (error: unknown) {
+          return createErrorResponse(
+            `Failed to update rich menu image: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+    );
+  }
+}

--- a/test/helpers/mock-line-clients.ts
+++ b/test/helpers/mock-line-clients.ts
@@ -9,11 +9,13 @@ export function createMockLineBotClient() {
     getMessageQuota: vi.fn(),
     getMessageQuotaConsumption: vi.fn(),
     getRichMenuList: vi.fn(),
+    getRichMenu: vi.fn(),
     deleteRichMenu: vi.fn(),
     setDefaultRichMenu: vi.fn(),
     cancelDefaultRichMenu: vi.fn(),
     createRichMenu: vi.fn(),
     getFollowers: vi.fn(),
     setRichMenuImage: vi.fn(),
+    getDefaultRichMenuId: vi.fn(),
   } as unknown as LineBotClient;
 }

--- a/test/tools/getRichMenu.test.ts
+++ b/test/tools/getRichMenu.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
+import GetRichMenu from "../../src/tools/getRichMenu.js";
+
+describe("get_rich_menu tool", () => {
+  let client: Client;
+  let server: McpServer;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
+
+  beforeEach(async () => {
+    mockLineClient = createMockLineBotClient();
+    server = new McpServer({ name: "test", version: "0.0.1" });
+    new GetRichMenu(mockLineClient).register(server);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "test-client", version: "0.0.1" });
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(serverTransport),
+    ]);
+  });
+
+  afterEach(async () => {
+    await client?.close();
+    await server?.close();
+  });
+
+  it("calls getRichMenu with the correct richMenuId and returns the rich menu", async () => {
+    const richMenu = {
+      richMenuId: "richmenu-123",
+      size: { width: 2500, height: 1686 },
+      chatBarText: "Menu",
+      areas: [],
+    };
+    vi.mocked(mockLineClient.getRichMenu).mockResolvedValue(richMenu as never);
+
+    const result = await client.callTool({
+      name: "get_rich_menu",
+      arguments: { richMenuId: "richmenu-123" },
+    });
+
+    expect(mockLineClient.getRichMenu).toHaveBeenCalledWith("richmenu-123");
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(JSON.parse(text)).toEqual(richMenu);
+  });
+
+  it("returns an error response when LINE API fails", async () => {
+    vi.mocked(mockLineClient.getRichMenu).mockRejectedValue(
+      new Error("Not found"),
+    );
+
+    const result = await client.callTool({
+      name: "get_rich_menu",
+      arguments: { richMenuId: "richmenu-unknown" },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("Failed to get rich menu");
+  });
+});

--- a/test/tools/updateRichMenuImage.test.ts
+++ b/test/tools/updateRichMenuImage.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import UpdateRichMenuImage from "../../src/tools/updateRichMenuImage.js";
+
+// Build a minimal PNG buffer whose IHDR header advertises the given dimensions.
+// The pixel data is not real; only the header bytes are read by the tool.
+function makePngBuffer(width: number, height: number): Buffer {
+  const buffer = Buffer.alloc(33);
+  // PNG signature
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(buffer, 0);
+  // IHDR length + type (not strictly parsed, kept for realism)
+  buffer.writeUInt32BE(13, 8);
+  buffer.write("IHDR", 12, "ascii");
+  buffer.writeUInt32BE(width, 16);
+  buffer.writeUInt32BE(height, 20);
+  return buffer;
+}
+
+function writeTempPng(width: number, height: number): string {
+  const filePath = path.join(
+    os.tmpdir(),
+    `update-rich-menu-image-test-${Date.now()}-${Math.random().toString(36).slice(2)}.png`,
+  );
+  fs.writeFileSync(filePath, makePngBuffer(width, height));
+  return filePath;
+}
+
+const OLD_RICH_MENU = {
+  richMenuId: "richmenu-old-123",
+  size: { width: 1600, height: 910 },
+  selected: true,
+  name: "My Menu",
+  chatBarText: "Menu",
+  areas: [
+    {
+      bounds: { x: 0, y: 0, width: 1600, height: 910 },
+      action: { type: "message", text: "hi" },
+    },
+  ],
+};
+
+describe("update_rich_menu_image tool", () => {
+  let client: Client;
+  let server: McpServer;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
+  const tempFiles: string[] = [];
+
+  function tempPng(width: number, height: number): string {
+    const p = writeTempPng(width, height);
+    tempFiles.push(p);
+    return p;
+  }
+
+  beforeEach(async () => {
+    mockLineClient = createMockLineBotClient();
+    server = new McpServer({ name: "test", version: "0.0.1" });
+    new UpdateRichMenuImage(mockLineClient).register(server);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "test-client", version: "0.0.1" });
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(serverTransport),
+    ]);
+  });
+
+  afterEach(async () => {
+    await client?.close();
+    await server?.close();
+    for (const f of tempFiles.splice(0)) {
+      try {
+        fs.unlinkSync(f);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  function parseResult(result: Awaited<ReturnType<Client["callTool"]>>) {
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    return JSON.parse(text);
+  }
+
+  it("clones the menu, uploads the image, switches default and deletes the old menu", async () => {
+    vi.mocked(mockLineClient.getRichMenu).mockResolvedValue(
+      OLD_RICH_MENU as never,
+    );
+    vi.mocked(mockLineClient.createRichMenu).mockResolvedValue({
+      richMenuId: "richmenu-new-456",
+    } as never);
+    vi.mocked(mockLineClient.setRichMenuImage).mockResolvedValue({} as never);
+    vi.mocked(mockLineClient.getDefaultRichMenuId).mockResolvedValue({
+      richMenuId: "richmenu-old-123",
+    } as never);
+    vi.mocked(mockLineClient.setDefaultRichMenu).mockResolvedValue({} as never);
+    vi.mocked(mockLineClient.deleteRichMenu).mockResolvedValue({} as never);
+
+    const imagePath = tempPng(1600, 910);
+    const result = await client.callTool({
+      name: "update_rich_menu_image",
+      arguments: { richMenuId: "richmenu-old-123", imagePath },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockLineClient.createRichMenu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "My Menu",
+        chatBarText: "Menu",
+        selected: true,
+        size: { width: 1600, height: 910 },
+      }),
+    );
+    expect(mockLineClient.setRichMenuImage).toHaveBeenCalledWith(
+      "richmenu-new-456",
+      expect.any(Blob),
+    );
+    expect(mockLineClient.setDefaultRichMenu).toHaveBeenCalledWith(
+      "richmenu-new-456",
+    );
+    expect(mockLineClient.deleteRichMenu).toHaveBeenCalledWith(
+      "richmenu-old-123",
+    );
+
+    const parsed = parseResult(result);
+    expect(parsed.oldRichMenuId).toBe("richmenu-old-123");
+    expect(parsed.newRichMenuId).toBe("richmenu-new-456");
+    expect(parsed.defaultSwitched).toBe(true);
+    expect(parsed.oldRichMenuDeleted).toBe(true);
+  });
+
+  it("does not switch the default when the old menu was not the default", async () => {
+    vi.mocked(mockLineClient.getRichMenu).mockResolvedValue(
+      OLD_RICH_MENU as never,
+    );
+    vi.mocked(mockLineClient.createRichMenu).mockResolvedValue({
+      richMenuId: "richmenu-new-456",
+    } as never);
+    vi.mocked(mockLineClient.setRichMenuImage).mockResolvedValue({} as never);
+    vi.mocked(mockLineClient.getDefaultRichMenuId).mockResolvedValue({
+      richMenuId: "richmenu-other-999",
+    } as never);
+    vi.mocked(mockLineClient.deleteRichMenu).mockResolvedValue({} as never);
+
+    const imagePath = tempPng(1600, 910);
+    const result = await client.callTool({
+      name: "update_rich_menu_image",
+      arguments: { richMenuId: "richmenu-old-123", imagePath },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockLineClient.setDefaultRichMenu).not.toHaveBeenCalled();
+    const parsed = parseResult(result);
+    expect(parsed.defaultSwitched).toBe(false);
+    expect(parsed.oldRichMenuDeleted).toBe(true);
+  });
+
+  it("does not delete the old menu when deleteOldRichMenu is false", async () => {
+    vi.mocked(mockLineClient.getRichMenu).mockResolvedValue(
+      OLD_RICH_MENU as never,
+    );
+    vi.mocked(mockLineClient.createRichMenu).mockResolvedValue({
+      richMenuId: "richmenu-new-456",
+    } as never);
+    vi.mocked(mockLineClient.setRichMenuImage).mockResolvedValue({} as never);
+    vi.mocked(mockLineClient.getDefaultRichMenuId).mockResolvedValue({
+      richMenuId: "richmenu-other-999",
+    } as never);
+
+    const imagePath = tempPng(1600, 910);
+    const result = await client.callTool({
+      name: "update_rich_menu_image",
+      arguments: {
+        richMenuId: "richmenu-old-123",
+        imagePath,
+        deleteOldRichMenu: false,
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockLineClient.deleteRichMenu).not.toHaveBeenCalled();
+    const parsed = parseResult(result);
+    expect(parsed.oldRichMenuDeleted).toBe(false);
+  });
+
+  it("returns an actionable error and does not create a menu when image size mismatches", async () => {
+    vi.mocked(mockLineClient.getRichMenu).mockResolvedValue(
+      OLD_RICH_MENU as never,
+    );
+
+    // Passes width/height/aspect-ratio checks but does not match the 1600x910 menu.
+    const imagePath = tempPng(2000, 910);
+    const result = await client.callTool({
+      name: "update_rich_menu_image",
+      arguments: { richMenuId: "richmenu-old-123", imagePath },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("2000x910");
+    expect(text).toContain("1600x910");
+    expect(mockLineClient.createRichMenu).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the newly created menu when the image upload fails", async () => {
+    vi.mocked(mockLineClient.getRichMenu).mockResolvedValue(
+      OLD_RICH_MENU as never,
+    );
+    vi.mocked(mockLineClient.createRichMenu).mockResolvedValue({
+      richMenuId: "richmenu-new-456",
+    } as never);
+    vi.mocked(mockLineClient.setRichMenuImage).mockRejectedValue(
+      new Error("upload failed"),
+    );
+    vi.mocked(mockLineClient.deleteRichMenu).mockResolvedValue({} as never);
+
+    const imagePath = tempPng(1600, 910);
+    const result = await client.callTool({
+      name: "update_rich_menu_image",
+      arguments: { richMenuId: "richmenu-old-123", imagePath },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockLineClient.deleteRichMenu).toHaveBeenCalledWith(
+      "richmenu-new-456",
+    );
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("upload failed");
+    expect(JSON.parse(text).rolledBack).toBe(true);
+  });
+
+  it("continues when getDefaultRichMenuId throws (no default set)", async () => {
+    vi.mocked(mockLineClient.getRichMenu).mockResolvedValue(
+      OLD_RICH_MENU as never,
+    );
+    vi.mocked(mockLineClient.createRichMenu).mockResolvedValue({
+      richMenuId: "richmenu-new-456",
+    } as never);
+    vi.mocked(mockLineClient.setRichMenuImage).mockResolvedValue({} as never);
+    vi.mocked(mockLineClient.getDefaultRichMenuId).mockRejectedValue(
+      new Error("404 not found"),
+    );
+    vi.mocked(mockLineClient.deleteRichMenu).mockResolvedValue({} as never);
+
+    const imagePath = tempPng(1600, 910);
+    const result = await client.callTool({
+      name: "update_rich_menu_image",
+      arguments: { richMenuId: "richmenu-old-123", imagePath },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockLineClient.setDefaultRichMenu).not.toHaveBeenCalled();
+    const parsed = parseResult(result);
+    expect(parsed.defaultSwitched).toBe(false);
+    expect(parsed.oldRichMenuDeleted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `get_rich_menu`: fetch a single rich menu (size, chat bar text, tap areas) by ID — the starting point for cloning an existing menu definition
- Add `update_rich_menu_image`: replace the image of an existing rich menu via **clone-and-replace**, since the LINE Messaging API does not allow overwriting an already uploaded image
  - Flow: fetch old menu definition → validate image → create new menu with the same definition → upload new image (rolls back the new menu on failure) → take over the default assignment if the old menu was the default → delete the old menu (`deleteOldRichMenu`, default `true`)
  - A new `richMenuId` is issued and returned; the old one becomes invalid

## Image validation (no new dependencies)

- Constraints stated in the tool/input schema descriptions: PNG/JPEG, width 800–2500px, height ≥250px, aspect ratio ≥1.45, max 1MB
- Dimensions are read by parsing the PNG IHDR / JPEG SOF headers directly
- Image dimensions must match the existing rich menu size; all validation errors are actionable (actual vs expected + what to do next), so an LLM caller can self-correct

## Test plan

- 8 new test cases (happy path, default takeover on/off, `deleteOldRichMenu=false`, dimension mismatch, upload-failure rollback, no default set)
- `npm test`: 16 files / 50 tests passed