### PR TITLE
feat: support multiple Flex messages in one push request

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,41 +23,46 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
      - `message.altText` (string): フレックスメッセージが表示できない場合に表示される代替テキスト。
      - `message.contents` (any): フレックスメッセージの内容。メッセージのレイアウトとコンポーネントを定義するJSONオブジェクト。
      - `message.contents.type` (enum): コンテナのタイプ。'bubble'は単一コンテナ、'carousel'は複数のスワイプ可能なバブルを示す。
-3. **broadcast_text_message**
+3. **push_flex_messages**
+   - 1〜5個のフレックスメッセージを、1回のLINE Messaging APIリクエストでユーザーに送信する。各項目は個別のメッセージとして表示されます。スワイプ可能なバブルには、1個のフレックスメッセージ内でcarouselを使用します。
+   - **入力:**
+     - `userId` (string?): メッセージ受信者のユーザーID。デフォルトはDESTINATION_USER_ID。`userId`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。
+     - `messages` (array): 1〜5個のフレックスメッセージオブジェクト。各項目は`push_flex_message`の`message`入力と同じスキーマを使用します。
+4. **broadcast_text_message**
    - LINE公式アカウントと友だちになっているすべてのユーザーに、LINEでシンプルなテキストメッセージを送信する。
    - **入力:**
      - `message.text` (string): ユーザーに送信するテキスト。
-4. **broadcast_flex_message**
+5. **broadcast_flex_message**
    - LINE公式アカウントと友だちになっているすべてのユーザーに、LINEで高度にカスタマイズ可能なフレックスメッセージを送信する。
    - **入力:**
      - `message.altText` (string): フレックスメッセージが表示できない場合に表示される代替テキスト。
      - `message.contents` (any): フレックスメッセージの内容。メッセージのレイアウトとコンポーネントを定義するJSONオブジェクト。
      - `message.contents.type` (enum): コンテナのタイプ。'bubble'は単一コンテナ、'carousel'は複数のスワイプ可能なバブルを示す。
-5. **get_profile**
+6. **get_profile**
    - LINEユーザーの詳細なプロフィール情報を取得する。表示名、プロフィール画像URL、ステータスメッセージ、言語を取得できる。
    - **入力:**
       - `userId` (string?): プロフィールを取得したいユーザーのユーザーID。デフォルトはDESTINATION_USER_ID。`userId`または`DESTINATION_USER_ID`のどちらか一方は必ず設定する必要があります。
-6. **get_message_quota**
+7. **get_message_quota**
    - LINE公式アカウントのメッセージ容量と消費量を取得します。月間メッセージ制限と現在の使用量が表示されます。
    - **入力:**
      - なし
-7. **get_rich_menu_list**
+8. **get_rich_menu_list**
    - LINE公式アカウントに登録されているリッチメニューの一覧を取得する。
    - **入力:**
      - なし
-8. **delete_rich_menu**
+9. **delete_rich_menu**
    - LINE公式アカウントからリッチメニューを削除する。
    - **入力:**
      - `richMenuId` (string): 削除するリッチメニューのID。
-9. **set_rich_menu_default**
+10. **set_rich_menu_default**
     - リッチメニューをデフォルトとして設定する。
     - **入力:**
       - `richMenuId` (string): デフォルトとして設定するリッチメニューのID。
-10. **cancel_rich_menu_default**
+11. **cancel_rich_menu_default**
     - デフォルトのリッチメニューを解除する。
     - **入力:**
       - なし
-11. **create_rich_menu**
+12. **create_rich_menu**
     - 指定されたアクションに基づいてリッチメニューを作成。画像を生成してアップロード。デフォルトとして設定する。
     - **入力:**
       - `chatBarText` (string): チャットバー表示、リッチメニュー名にされるテキスト。
@@ -72,7 +77,7 @@ LINE公式アカウントとAI Agentを接続するために、LINE Messaging AP
         - `richmenuswitch`: 別のリッチメニューに切り替える
         - `clipboard`: テキストをクリップボードにコピーする
 
-12. **get_follower_ids**
+13. **get_follower_ids**
     - LINE公式アカウントを友だち追加しているユーザーのユーザーIDリストを取得する。これにより、DESTINATION_USER_IDを手動で準備せずにユーザーIDを取得できる。
     - **入力:**
       - `start` (string?): 次のユーザーID配列を取得するための継続トークン。前回のレスポンスの`next`プロパティから取得できる。

--- a/README.md
+++ b/README.md
@@ -25,41 +25,46 @@
      - `message.altText` (string): Alternative text shown when flex message cannot be displayed.
      - `message.contents` (any): The contents of the flex message. This is a JSON object that defines the layout and components of the message.
      - `message.contents.type` (enum): Type of the container. 'bubble' for single container, 'carousel' for multiple swipeable bubbles.
-3. **broadcast_text_message**
+3. **push_flex_messages**
+   - Push one to five Flex messages to a user in a single LINE Messaging API request. Each item is displayed as a separate message; use a carousel inside one Flex message for swipeable bubbles.
+   - **Inputs:**
+     - `userId` (string?): The user ID to receive messages. Defaults to DESTINATION_USER_ID. Either `userId` or `DESTINATION_USER_ID` must be set.
+     - `messages` (array): One to five Flex message objects. Each item uses the same schema as `push_flex_message`'s `message` input.
+4. **broadcast_text_message**
    - Broadcast a simple text message via LINE to all users who have followed your LINE Official Account.
    - **Inputs:**
      - `message.text` (string): The plain text content to send to the users.
-4. **broadcast_flex_message**
+5. **broadcast_flex_message**
    - Broadcast a highly customizable flex message via LINE to all users who have added your LINE Official Account.
    - **Inputs:**
      - `message.altText` (string): Alternative text shown when flex message cannot be displayed.
      - `message.contents` (any): The contents of the flex message. This is a JSON object that defines the layout and components of the message.
      - `message.contents.type` (enum): Type of the container. 'bubble' for single container, 'carousel' for multiple swipeable bubbles.
-5. **get_profile**
+6. **get_profile**
    - Get detailed profile information of a LINE user including display name, profile picture URL, status message and language.
    - **Inputs:**
      - `userId` (string?): The ID of the user whose profile you want to retrieve. Defaults to DESTINATION_USER_ID.
-6. **get_message_quota**
+7. **get_message_quota**
    - Get the message quota and consumption of the LINE Official Account. This shows the monthly message limit and current usage.
    - **Inputs:**
      - None
-7. **get_rich_menu_list**
+8. **get_rich_menu_list**
    - Get the list of rich menus associated with your LINE Official Account.
    - **Inputs:**
      - None
-8. **delete_rich_menu**
+9. **delete_rich_menu**
    - Delete a rich menu from your LINE Official Account.
    - **Inputs:**
      - `richMenuId` (string): The ID of the rich menu to delete.
-9. **set_rich_menu_default**
+10. **set_rich_menu_default**
     - Set a rich menu as the default rich menu.
     - **Inputs:**
       - `richMenuId` (string): The ID of the rich menu to set as default.
-10. **cancel_rich_menu_default**
+11. **cancel_rich_menu_default**
     - Cancel the default rich menu.
     - **Inputs:**
       - None
-11. **create_rich_menu**
+12. **create_rich_menu**
     - Create a rich menu based on the given actions. Generate and upload an image. Set as default.
     - **Inputs:**
       - `chatBarText` (string): Text displayed in chat bar, also used as rich menu name.
@@ -74,7 +79,7 @@
         - `richmenuswitch`: For switching to another rich menu
         - `clipboard`: For copying text to clipboard
 
-12. **get_follower_ids**
+13. **get_follower_ids**
     - Get a list of user IDs of users who have added the LINE Official Account as a friend. This allows you to obtain user IDs for sending messages without manually preparing them.
     - **Inputs:**
       - `start` (string?): Continuation token to get the next array of user IDs. Returned in the `next` property of a previous response.

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,10 @@
       "description": "Send a rich, customizable flex message to a specific LINE user"
     },
     {
+      "name": "push_flex_messages",
+      "description": "Send one to five Flex messages to a specific LINE user in one request"
+    },
+    {
       "name": "broadcast_text_message",
       "description": "Send a plain text message to all followers"
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { LINE_BOT_MCP_SERVER_VERSION, USER_AGENT } from "./version.js";
 import CancelRichMenuDefault from "./tools/cancelRichMenuDefault.js";
 import PushTextMessage from "./tools/pushTextMessage.js";
 import PushFlexMessage from "./tools/pushFlexMessage.js";
+import PushFlexMessages from "./tools/pushFlexMessages.js";
 import BroadcastTextMessage from "./tools/broadcastTextMessage.js";
 import BroadcastFlexMessage from "./tools/broadcastFlexMessage.js";
 import GetProfile from "./tools/getProfile.js";
@@ -52,6 +53,7 @@ const lineBotClient = line.LineBotClient.fromChannelAccessToken({
 
 new PushTextMessage(lineBotClient, destinationId).register(server);
 new PushFlexMessage(lineBotClient, destinationId).register(server);
+new PushFlexMessages(lineBotClient, destinationId).register(server);
 new BroadcastTextMessage(lineBotClient).register(server);
 new BroadcastFlexMessage(lineBotClient).register(server);
 new GetProfile(lineBotClient, destinationId).register(server);

--- a/src/tools/pushFlexMessages.ts
+++ b/src/tools/pushFlexMessages.ts
@@ -1,0 +1,63 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { LineBotClient, messagingApi } from "@line/bot-sdk";
+import { z } from "zod";
+import {
+  createErrorResponse,
+  createSuccessResponse,
+} from "../common/response.js";
+import { AbstractTool } from "./AbstractTool.js";
+import { NO_USER_ID_ERROR } from "../common/schema/constants.js";
+import { flexMessageSchema } from "../common/schema/flexMessage.js";
+
+export default class PushFlexMessages extends AbstractTool {
+  private client: LineBotClient;
+  private destinationId: string;
+
+  constructor(client: LineBotClient, destinationId: string) {
+    super();
+    this.client = client;
+    this.destinationId = destinationId;
+  }
+
+  register(server: McpServer) {
+    const userIdSchema = z
+      .string()
+      .default(this.destinationId)
+      .describe(
+        "The user ID to receive messages. Defaults to DESTINATION_USER_ID.",
+      );
+
+    server.registerTool(
+      "push_flex_messages",
+      {
+        title: "Push Flex Messages",
+        description:
+          "Push one to five Flex messages to a user in a single LINE Messaging API request. Each message is displayed separately.",
+        inputSchema: {
+          userId: userIdSchema,
+          messages: z.array(flexMessageSchema).min(1).max(5),
+        },
+        annotations: {
+          destructiveHint: true,
+        },
+      },
+      async ({ userId, messages }) => {
+        if (!userId) {
+          return createErrorResponse(NO_USER_ID_ERROR);
+        }
+
+        try {
+          const response = await this.client.pushMessage({
+            to: userId,
+            messages: messages as unknown as messagingApi.Message[],
+          });
+          return createSuccessResponse(response);
+        } catch (error: unknown) {
+          return createErrorResponse(
+            `Failed to push flex messages: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+    );
+  }
+}

--- a/test/tools/pushFlexMessages.test.ts
+++ b/test/tools/pushFlexMessages.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { NO_USER_ID_ERROR } from "../../src/common/schema/constants.js";
+import PushFlexMessages from "../../src/tools/pushFlexMessages.js";
+import { createMockLineBotClient } from "../helpers/mock-line-clients.js";
+
+const DESTINATION_ID = "U_DEFAULT_USER";
+
+const createFlexMessage = (label: string) => ({
+  type: "flex",
+  altText: `${label} flex message`,
+  contents: {
+    type: "bubble",
+    body: {
+      type: "box",
+      layout: "vertical",
+      contents: [{ type: "text", text: label }],
+    },
+  },
+});
+
+// Zod schema applies default values (e.g. wrap: true for text elements)
+const createExpectedFlexMessage = (label: string) => ({
+  type: "flex",
+  altText: `${label} flex message`,
+  contents: {
+    type: "bubble",
+    body: {
+      type: "box",
+      layout: "vertical",
+      contents: [{ type: "text", text: label, wrap: true }],
+    },
+  },
+});
+
+describe("push_flex_messages tool", () => {
+  let client: Client;
+  let server: McpServer;
+  let mockLineClient: ReturnType<typeof createMockLineBotClient>;
+
+  beforeEach(async () => {
+    mockLineClient = createMockLineBotClient();
+    server = new McpServer({ name: "test", version: "0.0.1" });
+    new PushFlexMessages(mockLineClient, DESTINATION_ID).register(server);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "test-client", version: "0.0.1" });
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(serverTransport),
+    ]);
+  });
+
+  afterEach(async () => {
+    await client?.close();
+    await server?.close();
+  });
+
+  it("pushes three Flex messages in order with one API call", async () => {
+    vi.mocked(mockLineClient.pushMessage).mockResolvedValue({} as never);
+
+    const result = await client.callTool({
+      name: "push_flex_messages",
+      arguments: {
+        userId: "U_EXPLICIT_USER",
+        messages: [
+          createFlexMessage("C"),
+          createFlexMessage("A"),
+          createFlexMessage("B"),
+        ],
+      },
+    });
+
+    expect(mockLineClient.pushMessage).toHaveBeenCalledTimes(1);
+    expect(mockLineClient.pushMessage).toHaveBeenCalledWith({
+      to: "U_EXPLICIT_USER",
+      messages: [
+        createExpectedFlexMessage("C"),
+        createExpectedFlexMessage("A"),
+        createExpectedFlexMessage("B"),
+      ],
+    });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("pushes one Flex message", async () => {
+    vi.mocked(mockLineClient.pushMessage).mockResolvedValue({} as never);
+
+    const result = await client.callTool({
+      name: "push_flex_messages",
+      arguments: {
+        userId: "U_EXPLICIT_USER",
+        messages: [createFlexMessage("Only")],
+      },
+    });
+
+    expect(mockLineClient.pushMessage).toHaveBeenCalledTimes(1);
+    expect(mockLineClient.pushMessage).toHaveBeenCalledWith({
+      to: "U_EXPLICIT_USER",
+      messages: [createExpectedFlexMessage("Only")],
+    });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("uses default destinationId when userId is omitted", async () => {
+    vi.mocked(mockLineClient.pushMessage).mockResolvedValue({} as never);
+
+    await client.callTool({
+      name: "push_flex_messages",
+      arguments: {
+        messages: [createFlexMessage("Default recipient")],
+      },
+    });
+
+    expect(mockLineClient.pushMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ to: DESTINATION_ID }),
+    );
+  });
+
+  it("rejects an empty messages array before calling LINE", async () => {
+    const result = await client.callTool({
+      name: "push_flex_messages",
+      arguments: {
+        userId: "U_USER",
+        messages: [],
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockLineClient.pushMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects more than five messages before calling LINE", async () => {
+    const result = await client.callTool({
+      name: "push_flex_messages",
+      arguments: {
+        userId: "U_USER",
+        messages: Array.from({ length: 6 }, (_, index) =>
+          createFlexMessage(String(index + 1)),
+        ),
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockLineClient.pushMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns the standard error when no recipient is available", async () => {
+    const emptyServer = new McpServer({ name: "test", version: "0.0.1" });
+    new PushFlexMessages(mockLineClient, "").register(emptyServer);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const emptyClient = new Client({ name: "test-client", version: "0.0.1" });
+    await Promise.all([
+      emptyClient.connect(clientTransport),
+      emptyServer.connect(serverTransport),
+    ]);
+
+    const result = await emptyClient.callTool({
+      name: "push_flex_messages",
+      arguments: {
+        messages: [createFlexMessage("No recipient")],
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([{ type: "text", text: NO_USER_ID_ERROR }]);
+    expect(mockLineClient.pushMessage).not.toHaveBeenCalled();
+
+    await emptyClient.close();
+    await emptyServer.close();
+  });
+
+  it("returns a readable error when LINE API fails", async () => {
+    vi.mocked(mockLineClient.pushMessage).mockRejectedValue(
+      new Error("API error"),
+    );
+
+    const result = await client.callTool({
+      name: "push_flex_messages",
+      arguments: {
+        userId: "U_USER",
+        messages: [createFlexMessage("Failure")],
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("Failed to push flex messages");
+    expect(text).toContain("API error");
+    expect(text).not.toContain("CHANNEL_ACCESS_TOKEN");
+  });
+
+  it("lists a messages array limited to one through five items", async () => {
+    const { tools } = await client.listTools();
+    const tool = tools.find(({ name }) => name === "push_flex_messages");
+    const messagesSchema = tool?.inputSchema.properties?.messages as
+      { minItems?: number; maxItems?: number } | undefined;
+
+    expect(tool).toBeDefined();
+    expect(messagesSchema).toMatchObject({
+      minItems: 1,
+      maxItems: 5,
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`push_flex_message` accepts only one Flex message, while the LINE Messaging API supports up to five message objects in a single push request.

## Solution

- Add `push_flex_messages` for one to five Flex message objects.
- Pass the ordered `messages` array to one `client.pushMessage` call.
- Keep `push_flex_message` unchanged, so existing users do not need to migrate.

## Validation

- `npm run format:check`
- `npm run build`
- `npm test` (15 test files, 50 tests)
- `npm run check:publint`
- `git diff upstream/main...HEAD --check`
- Local stdio non-send validation confirmed the tool appears in `tools/list` with `minItems: 1` and `maxItems: 5`.
- Tests confirm three ordered messages result in one LINE client call, one message succeeds, and zero or six messages are rejected before the LINE client is called.
- Existing `push_flex_message` tests remain unchanged and pass.

## Docs

The English and Japanese READMEs and `manifest.json` include the new tool. The Japanese copy mirrors the English scope; wording feedback is welcome.

## References

- https://developers.line.biz/en/docs/messaging-api/sending-messages/
- https://developers.line.biz/en/docs/messaging-api/pricing/
- https://developers.line.biz/en/reference/messaging-api/#send-push-message

The number of message objects in one request does not affect the sent-message count; actual usage still depends on the subscription plan and recipient count.

## Out of scope

- Arbitrary message types
- Broadcast or multicast behavior
- Report-specific UI or payloads
